### PR TITLE
Ensure Firebase analytics block remains visible on blackjack page

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -342,6 +342,7 @@ setButtons('deal'); // initial state
 </script>
 
 <script type="module">
+  // Firebase Analytics integration for usage tracking
   // Import the functions you need from the SDKs you need
   import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
   import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";


### PR DESCRIPTION
## Summary
- add an inline comment above the Firebase analytics module import block to make it easier to spot in view-source checks

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6263cb7f08325bd25d583e14d78ce