### PR TITLE
Update Firebase analytics initialization in blackjack page

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -342,16 +342,9 @@ setButtons('deal'); // initial state
 </script>
 
 <script type="module">
-  // Firebase Analytics integration for usage tracking
-  // Import the functions you need from the SDKs you need
   import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
-  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
+  import { getAnalytics, isSupported } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
 
-  // TODO: Add SDKs for Firebase products that you want to use
-  // https://firebase.google.com/docs/web/setup#available-libraries
-
-  // Your web app's Firebase configuration
-  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
   const firebaseConfig = {
     apiKey: "AIzaSyDRniZatGeylxphjHQadYjucOcirNBRIdk",
     authDomain: "multiplayer-640ec.firebaseapp.com",
@@ -363,9 +356,14 @@ setButtons('deal'); // initial state
     measurementId: "G-V43J1S8RGF"
   };
 
-  // Initialize Firebase
   const app = initializeApp(firebaseConfig);
-  const analytics = getAnalytics(app);
+  isSupported()
+    .then((supported) => {
+      if (supported) {
+        getAnalytics(app);
+      }
+    })
+    .catch((err) => console.warn("Firebase analytics not supported", err));
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update the Firebase analytics module block in `blackjack.html` to use the newer initialization snippet while keeping the existing configuration
- guard analytics initialization behind an isSupported check with logging for unsupported environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6279153208325aa317e895cb4a52c