### PR TITLE
Guard analytics initialization on index page

### DIFF
--- a/index.html
+++ b/index.html
@@ -366,7 +366,7 @@
     <script type="module">
         // Import the functions you need from the SDKs you need
         import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";
-        import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
+        import { getAnalytics, isSupported } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-analytics.js";
 
         // TODO: Add SDKs for Firebase products that you want to use
         // https://firebase.google.com/docs/web/setup#available-libraries
@@ -386,7 +386,13 @@
 
         // Initialize Firebase
         const app = initializeApp(firebaseConfig);
-        const analytics = getAnalytics(app);
+        isSupported()
+            .then((supported) => {
+                if (supported) {
+                    getAnalytics(app);
+                }
+            })
+            .catch((err) => console.warn("Firebase analytics not supported", err));
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- import the Firebase analytics isSupported helper on the index page
- wrap getAnalytics in an isSupported check with graceful error logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d63078311c8325b0859f51676e0c08