### PR TITLE
Fix blackjack lobby buttons failing to respond

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -420,13 +420,6 @@
     setTimeout(()=> input.classList.remove('invalid'), 1600);
   }
 
-  if(hostNameInput){
-    hostNameInput.value = playerName;
-  }
-  if(joinNameInput){
-    joinNameInput.value = playerName;
-  }
-
   function setButtons(state){
     const on = (el, ok)=> el.classList.toggle('muted', !ok);
     switch(state){
@@ -559,6 +552,13 @@
     }
   }catch(err){
     console.debug('Unable to access stored player name', err);
+  }
+
+  if(hostNameInput){
+    hostNameInput.value = playerName;
+  }
+  if(joinNameInput){
+    joinNameInput.value = playerName;
   }
 
   let roomId = null;


### PR DESCRIPTION
## Summary
- move the blackjack lobby name prefill logic to after the player name is initialized
- prevent the runtime error that blocked Singleplayer and Multiplayer button handlers so the lobby can close/switch cards

## Testing
- browser_container.run_playwright_script (playwright check of lobby buttons)


------
https://chatgpt.com/codex/tasks/task_e_68d7352b4dcc8325bb487d2f012b9c3e