### PR TITLE
Revamp rat race betting lobby

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -139,7 +139,25 @@
   .btn.secondary{ background:linear-gradient(135deg,#2e3757,#1e263f); color:#e9eef6; border:1px solid rgba(255,255,255,.14) }
   .btn.muted{ opacity:.6; pointer-events:none }
 
-  table{ width:100%; border-collapse:separate; border-spacing:0 10px; font-variant-numeric:tabular-nums; }
+  .players{ display:grid; gap:16px; grid-template-columns:repeat(auto-fit,minmax(240px,1fr)); margin-top:1rem; }
+  .playerCard{ background:rgba(7,11,24,.85); border:1px solid rgba(255,255,255,.1); padding:16px; border-radius:18px; box-shadow:0 18px 28px rgba(0,0,0,.4); display:flex; flex-direction:column; gap:14px; position:relative; overflow:hidden; }
+  .playerCard::after{ content:""; position:absolute; inset:0; border-radius:inherit; pointer-events:none; background:linear-gradient(120deg, rgba(255,255,255,.08) 0%, rgba(255,255,255,0) 40%); opacity:.35; }
+  .playerHeader{ display:flex; align-items:center; justify-content:space-between; gap:12px; position:relative; z-index:1; }
+  .playerName{ font-weight:700; letter-spacing:.06em; text-transform:uppercase; }
+  .playerMeta{ color:var(--muted); font-size:.82rem; }
+  .avatar{ width:40px; height:40px; border-radius:50%; display:grid; place-items:center; font-weight:800; letter-spacing:.04em; background:linear-gradient(135deg, rgba(255,209,59,.26), rgba(255,139,36,.18)); color:var(--accent); box-shadow:0 10px 18px rgba(0,0,0,.4); }
+  .betList{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:10px; position:relative; z-index:1; }
+  .bet{ display:flex; align-items:center; justify-content:space-between; gap:10px; padding:10px 12px; border-radius:12px; background:rgba(14,22,38,.8); border:1px solid rgba(255,255,255,.08); box-shadow:inset 0 0 0 1px rgba(255,255,255,.04); }
+  .betInfo{ display:flex; flex-direction:column; gap:2px; }
+  .betInfo strong{ font-size:.95rem; letter-spacing:.04em; }
+  .betInfo span{ color:var(--muted); font-size:.8rem; text-transform:uppercase; letter-spacing:.1em; }
+  .betAmount{ font-weight:800; letter-spacing:.08em; }
+  .remove-btn{ appearance:none; border:0; background:rgba(255,255,255,.08); color:var(--muted); border-radius:8px; padding:.25rem .55rem; cursor:pointer; font-size:.9rem; }
+  .remove-btn:hover{ background:rgba(255,255,255,.16); color:var(--text); }
+  .remove-btn:disabled{ opacity:.35; pointer-events:none; }
+  .emptyState{ margin:1.2rem 0 0; padding:1.4rem; border-radius:14px; background:rgba(7,11,24,.7); border:1px dashed rgba(255,255,255,.16); text-align:center; color:var(--muted); letter-spacing:.04em; }
+
+  table{ width:100%; border-collapse:separate; border-spacing:0 10px; font-variant-numeric:tabular-nums; margin-top:1rem; }
   th, td{ text-align:left; padding:.65rem .9rem; }
   th{ color:var(--muted); font-weight:700; font-size:.85rem; text-transform:uppercase; letter-spacing:.08em; }
   tbody tr{ background:rgba(7,11,24,.85); border:1px solid rgba(255,255,255,.08); box-shadow:0 12px 18px rgba(0,0,0,.35); transition:transform .18s ease, box-shadow .18s ease; }
@@ -185,10 +203,11 @@
         <button class="btn secondary" id="reset">New Race</button>
       </div>
 
-      <table>
-        <thead><tr><th>Bettor</th><th>Rat</th><th class="right">Amount</th><th class="right">Remove</th></tr></thead>
-        <tbody id="betRows"></tbody>
-      </table>
+      <div id="playerGrid" class="players"></div>
+
+      <div id="emptyBets" class="emptyState" hidden>
+        Waiting for players… add bets to build the lobby.
+      </div>
 
       <div class="note">
         Payouts are pari-mutuel: winners split the pot in proportion to their bet. If nobody bet the winning rat, the house keeps the pot (😼).
@@ -247,7 +266,10 @@ for(const r of RAT_DATA){
 
 /* ============== Betting state ============== */
 let bets = []; // {id, name, ratId, amount}
-const betRows = document.getElementById('betRows');
+let locked = false;
+let guestCounter = 1;
+const playerGrid = document.getElementById('playerGrid');
+const emptyBets = document.getElementById('emptyBets');
 const resultRows = document.getElementById('resultRows');
 
 function fmt(n){ return '$'+Number(n).toLocaleString(undefined,{minimumFractionDigits:0}); }
@@ -255,35 +277,81 @@ function pot(){ return bets.reduce((a,b)=>a+Number(b.amount||0),0); }
 function totalOn(rid){ return bets.filter(b=>b.ratId===rid).reduce((a,b)=>a+Number(b.amount),0); }
 
 function redrawBets(){
-  betRows.innerHTML = '';
+  playerGrid.innerHTML = '';
   if(!bets.length){
-    const tr = document.createElement('tr');
-    tr.innerHTML = `<td colspan="4" style="color:var(--muted)">No bets yet.</td>`;
-    betRows.appendChild(tr);
+    emptyBets.hidden = false;
   }else{
-    for(const b of bets){
-      const tr = document.createElement('tr');
-      tr.innerHTML = `
-        <td>${escapeHTML(b.name||'—')}</td>
-        <td>${ratName(b.ratId)}</td>
-        <td class="right">${fmt(b.amount)}</td>
-        <td class="right"><button class="btn secondary" data-remove="${b.id}" style="padding:.4rem .6rem">×</button></td>`;
-      betRows.appendChild(tr);
+    emptyBets.hidden = true;
+    const grouped = new Map();
+    for(const bet of bets){
+      if(!grouped.has(bet.name)){
+        grouped.set(bet.name, { name: bet.name, bets: [], total:0 });
+      }
+      const entry = grouped.get(bet.name);
+      entry.bets.push(bet);
+      entry.total += Number(bet.amount);
+    }
+    const players = Array.from(grouped.values()).sort((a,b)=>b.total - a.total);
+    for(const player of players){
+      const card = document.createElement('div');
+      card.className = 'playerCard';
+      const statusLabel = locked ? 'Locked in' : 'Live bet';
+      card.innerHTML = `
+        <div class="playerHeader">
+          <div style="display:flex;align-items:center;gap:12px;">
+            <div class="avatar">${escapeHTML(initials(player.name))}</div>
+            <div>
+              <div class="playerName">${escapeHTML(player.name)}</div>
+              <div class="playerMeta">${player.bets.length} bet${player.bets.length>1?'s':''} · ${fmt(player.total)}</div>
+            </div>
+          </div>
+          <div class="playerMeta">${statusLabel}</div>
+        </div>
+        <ul class="betList">
+          ${player.bets.map(b=>`
+            <li class="bet">
+              <div class="betInfo">
+                <strong>${escapeHTML(ratName(b.ratId))}</strong>
+                <span>Lane ${laneNumber(b.ratId)}</span>
+              </div>
+              <div style="display:flex;align-items:center;gap:8px;">
+                <span class="betAmount">${fmt(b.amount)}</span>
+                <button class="remove-btn" data-remove="${b.id}" ${locked?'disabled':''}>×</button>
+              </div>
+            </li>
+          `).join('')}
+        </ul>
+      `;
+      playerGrid.appendChild(card);
     }
   }
   potEl.textContent = fmt(pot());
 }
 function escapeHTML(s){ return (s??'').replace(/[&<>"']/g,m=>({"&":"&amp;","<":"&lt;",">":"&gt;","\"":"&quot;","'":"&#039;"}[m])); }
 function ratName(id){ return RAT_DATA.find(r=>r.id===id)?.name || id; }
+function laneNumber(id){ const idx = RAT_DATA.findIndex(r=>r.id===id); return idx>=0 ? idx+1 : '?'; }
+function initials(name){
+  const parts = name.split(/\s+/).filter(Boolean);
+  if(!parts.length) return '??';
+  const first = parts[0][0] || '';
+  const second = parts.length>1 ? parts[parts.length-1][0] || '' : (parts[0][1] || '');
+  return (first + second).toUpperCase();
+}
 
 document.getElementById('addBet').addEventListener('click', ()=>{
-  const name = document.getElementById('bettor').value.trim();
+  if(locked) return;
+  let name = document.getElementById('bettor').value.trim();
+  if(!name){
+    name = `Guest ${guestCounter++}`;
+    document.getElementById('bettor').value = name;
+  }
   const ratId = document.getElementById('rat').value;
   const amount = Math.max(1, Math.floor(Number(document.getElementById('amount').value||0)));
   bets.push({ id:crypto.randomUUID(), name, ratId, amount });
   redrawBets();
 });
-betRows.addEventListener('click', (e)=>{
+playerGrid.addEventListener('click', (e)=>{
+  if(locked) return;
   const id = e.target?.dataset?.remove;
   if(!id) return;
   bets = bets.filter(b=>b.id!==id);
@@ -369,6 +437,7 @@ document.getElementById('closeBets').addEventListener('click', async ()=>{
   if(!bets.length) { statusEl.textContent = 'Place at least one bet.'; return; }
   // Lock betting UI
   toggleBetUI(true);
+  statusEl.textContent = 'Bets locked! Racers to the line…';
   await startCountdown();
   startRace();
 });
@@ -379,14 +448,17 @@ document.getElementById('reset').addEventListener('click', ()=>{
   statusEl.textContent = 'Place your bets.';
   toggleBetUI(false);
   resetRacePositions();
+  guestCounter = 1;
 });
 
 function toggleBetUI(lock){
+  locked = lock;
   document.getElementById('addBet').classList.toggle('muted', lock);
   document.getElementById('closeBets').classList.toggle('muted', lock);
   for(const el of [document.getElementById('bettor'), document.getElementById('rat'), document.getElementById('amount')]){
     el.disabled = lock;
   }
+  redrawBets();
 }
 
 /* ============== Utilities & SVG ============== */


### PR DESCRIPTION
## Summary
- restyle the betting panel with player cards, avatars, and an empty lobby state so bets are grouped per person
- lock the lobby once races start, reflecting the state in the UI and disabling bet edits during the countdown
- auto-assign guest names for unnamed bettors to keep multiplayer cards organized

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d73dfda34483259eba331acfc5a7ed