### PR TITLE
Remove project overview text from main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -670,20 +670,9 @@
                     </div>
                 </div>
             </div>
-            <h1>Project Vault</h1>
-            <p class="lede">A curated gallery of the experiments, games, and ideas we are shaping for the crew. Dive straight into what's live and peek at what's brewing next.</p>
-            <div class="header-meta">
-                <span class="meta-chip">Updated regularly</span>
-                <span class="meta-chip">Sylveon-inspired palette</span>
-            </div>
         </header>
 
-        <section class="projects" aria-labelledby="project-heading">
-            <div class="section-heading">
-                <h2 id="project-heading">Project roster</h2>
-                <p>All the action in one place—no extra clicks needed. Explore current builds and keep an eye on the concepts waiting in the wings.</p>
-            </div>
-
+        <section class="projects">
             <div class="project-grid">
                 <article class="project-card" data-status="live">
                     <div class="card-top">
@@ -691,10 +680,6 @@
                         <span class="tag">Game</span>
                     </div>
                     <h3>Blackjack Lounge</h3>
-                    <p>Classic 21 with a velvet neon glow. Shuffle, deal, and see if you can outsmart the dealer under the pastel lights.</p>
-                    <div class="project-meta">
-                        <span>Last major update · <time datetime="2024-05-10">May 10, 2024</time></span>
-                    </div>
                     <a class="cta" href="blackjack.html">Launch table</a>
                 </article>
 
@@ -704,10 +689,6 @@
                         <span class="tag">Rhythm</span>
                     </div>
                     <h3>Rhythm Reactor</h3>
-                    <p>Fast-paced music challenge blending osu!-style hits with memory sparkles. Currently sourcing tracks and chart ideas.</p>
-                    <div class="project-meta">
-                        <span>Concept phase · <time datetime="2024-04-27">Apr 27, 2024</time></span>
-                    </div>
                     <span class="cta disabled">Stay tuned</span>
                 </article>
 
@@ -717,10 +698,6 @@
                         <span class="tag">Game</span>
                     </div>
                     <h3>Rat Race</h3>
-                    <p>Pick your favorite neon-fueled racer and cheer as the rats dash across the arcade track toward glory.</p>
-                    <div class="project-meta">
-                        <span>Launched for the crew · <time datetime="2024-06-05">Jun 5, 2024</time></span>
-                    </div>
                     <a class="cta" href="RatRace.html">Enter race</a>
                 </article>
 
@@ -730,10 +707,6 @@
                         <span class="tag">Wildcard</span>
                     </div>
                     <h3>Mystery Slot</h3>
-                    <p>Pitch something wild and wonderful. Bonus points if it sparks chaos—in the best Sylveon-tinted way.</p>
-                    <div class="project-meta">
-                        <span>Ideas welcome · <time datetime="2024-03-15">Mar 15, 2024</time></span>
-                    </div>
                     <span class="cta disabled">Accepting ideas</span>
                 </article>
             </div>


### PR DESCRIPTION
## Summary
- remove the Project Vault hero copy so the header only shows the account controls
- strip the project roster heading, descriptions, and update metadata from the project grid cards

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d75068a8848325a11db9e6ad375691