### PR TITLE
Add persistent back navigation to arcade pages

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -30,6 +30,24 @@
       linear-gradient(160deg, #05060d 0%, #090f1f 60%, #0c1228 100%);
     display:flex; min-height:100dvh; align-items:center; justify-content:center; padding:24px 0;
   }
+  .back-nav{
+    position:fixed; top:20px; right:22px; z-index:20;
+  }
+  .back-nav__button{
+    appearance:none; border:1px solid rgba(232,238,246,.35);
+    background:linear-gradient(135deg, rgba(18,26,45,.82), rgba(9,14,28,.92));
+    color:var(--text); border-radius:999px; display:inline-flex; align-items:center; gap:.45rem;
+    padding:.55rem 1.15rem; font-weight:700; letter-spacing:.05em; cursor:pointer;
+    box-shadow:0 20px 36px rgba(0,0,0,.4); transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+  }
+  .back-nav__button:hover,
+  .back-nav__button:focus-visible{
+    transform:translateY(-1px);
+    border-color:rgba(255,209,59,.6);
+    box-shadow:0 26px 44px rgba(0,0,0,.48);
+    outline:none;
+  }
+  .back-nav__icon{font-size:1.05rem; line-height:1;}
   .wrap{
     width:min(1240px,96vw); margin:0 auto; display:grid; gap:22px;
     grid-template-columns: 1.15fr .85fr; align-items:start;
@@ -267,6 +285,12 @@
 </style>
 </head>
 <body>
+  <div class="back-nav" role="navigation" aria-label="Page navigation">
+    <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
+      <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
+      <span class="back-nav__text">Back</span>
+    </button>
+  </div>
   <div class="wrap">
     <!-- TRACK -->
     <div class="track" id="track">
@@ -342,6 +366,22 @@
       </table>
     </div>
   </div>
+
+  <script>
+    function handleBack(event){
+      if(event){
+        event.preventDefault();
+      }
+
+      const home = event?.currentTarget?.dataset?.home || 'index.html';
+
+      if(window.history.length > 1){
+        window.history.back();
+      }else{
+        window.location.href = home;
+      }
+    }
+  </script>
 
 <script type="module">
 import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";

--- a/blackjack.html
+++ b/blackjack.html
@@ -21,6 +21,24 @@
     margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;
     color:var(--text); background:#0b1020; display:grid; place-items:center;
   }
+  .back-nav{
+    position:fixed; top:18px; right:18px; z-index:10;
+  }
+  .back-nav__button{
+    appearance:none; border:1px solid rgba(233,241,238,.35);
+    background:linear-gradient(135deg, rgba(14,23,36,.85), rgba(11,16,30,.92));
+    color:var(--text); border-radius:999px; display:inline-flex; align-items:center;
+    gap:.4rem; padding:.5rem 1.1rem; font-weight:700; letter-spacing:.04em; cursor:pointer;
+    box-shadow:0 18px 32px rgba(0,0,0,.35); transition:transform .2s ease, box-shadow .2s ease, border-color .2s ease;
+  }
+  .back-nav__button:hover,
+  .back-nav__button:focus-visible{
+    transform:translateY(-1px);
+    border-color:rgba(255,209,59,.6);
+    box-shadow:0 24px 40px rgba(0,0,0,.45);
+    outline:none;
+  }
+  .back-nav__icon{font-size:1.05rem; line-height:1;}
   .table{
     position:relative; width:min(1100px, 96vw); aspect-ratio: 16/9;
     background: radial-gradient(120% 90% at 50% -15%, #208b6e 0, var(--felt) 32%, var(--felt-dark) 95%);
@@ -212,14 +230,6 @@
   }
   .status.show{ opacity:1 }
 
-  /* Exit link */
-  .back-link{
-    position:absolute; top:16px; right:20px; z-index:4; display:inline-flex; align-items:center;
-    gap:.4rem; font-size:.95rem; text-decoration:none; font-weight:600; color:var(--text);
-    background:rgba(0,0,0,.35); padding:.45rem .8rem; border-radius:999px; transition:background .2s ease, transform .2s ease;
-  }
-  .back-link:hover{ background:rgba(0,0,0,.55); transform:translateY(-1px); }
-
   .hidden{ display:none !important; }
 
   .lobby{
@@ -257,7 +267,12 @@
 </style>
 </head>
 <body>
-  <a class="back-link" href="index.html">← Back to the friend hub</a>
+  <div class="back-nav" role="navigation" aria-label="Page navigation">
+    <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
+      <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
+      <span class="back-nav__text">Back</span>
+    </button>
+  </div>
   <div class="lobby" id="lobby">
     <div class="lobby-card" id="lobbyMain">
       <h2>Blackjack Lounge</h2>
@@ -319,6 +334,22 @@
       <button class="ghost" id="btnNew">New Shoe</button>
     </div>
   </div>
+
+  <script>
+    function handleBack(event){
+      if(event){
+        event.preventDefault();
+      }
+
+      const home = event?.currentTarget?.dataset?.home || 'index.html';
+
+      if(window.history.length > 1){
+        window.history.back();
+      }else{
+        window.location.href = home;
+      }
+    }
+  </script>
 
 <script type="module">
   import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";

--- a/index.html
+++ b/index.html
@@ -47,6 +47,43 @@
             padding: clamp(1.6rem, 4vw, 3.5rem);
         }
 
+        .back-nav {
+            position: fixed;
+            top: clamp(0.9rem, 2vw, 1.6rem);
+            right: clamp(0.9rem, 2vw, 1.6rem);
+            z-index: 40;
+        }
+
+        .back-nav__button {
+            appearance: none;
+            border: 1px solid rgba(147, 198, 255, 0.35);
+            background: linear-gradient(135deg, rgba(31, 21, 58, 0.82), rgba(11, 7, 27, 0.88));
+            color: var(--text-primary);
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            gap: 0.45rem;
+            padding: 0.55rem 1.2rem;
+            font-weight: 600;
+            letter-spacing: 0.02em;
+            cursor: pointer;
+            box-shadow: 0 18px 35px rgba(5, 3, 17, 0.35);
+            transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease;
+        }
+
+        .back-nav__button:hover,
+        .back-nav__button:focus-visible {
+            transform: translateY(-1px);
+            border-color: rgba(247, 167, 218, 0.65);
+            box-shadow: 0 25px 45px rgba(5, 3, 17, 0.45);
+            outline: none;
+        }
+
+        .back-nav__icon {
+            font-size: 1.1rem;
+            line-height: 1;
+        }
+
         .page {
             width: min(1100px, 100%);
             display: grid;
@@ -594,6 +631,12 @@
     </style>
 </head>
 <body>
+    <div class="back-nav" role="navigation" aria-label="Page navigation">
+        <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
+            <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
+            <span class="back-nav__text">Back</span>
+        </button>
+    </div>
     <main class="page">
         <header class="page-header">
             <div class="header-bar">
@@ -739,6 +782,22 @@
             </form>
         </div>
     </div>
+
+    <script>
+        function handleBack(event) {
+            if (event) {
+                event.preventDefault();
+            }
+
+            const home = event?.currentTarget?.dataset?.home || "index.html";
+
+            if (window.history.length > 1) {
+                window.history.back();
+            } else {
+                window.location.href = home;
+            }
+        }
+    </script>
 
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/12.3.0/firebase-app.js";


### PR DESCRIPTION
## Summary
- add a fixed back navigation control style that fits each page theme
- inject top-right back buttons on the hub, Blackjack, and Rat Race pages
- provide a shared back handler that prefers history navigation with an index fallback

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d7512d2f6083258dcfc34e424c221f