### PR TITLE
Update exit navigation for game pages

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -339,10 +339,10 @@
 </style>
 </head>
 <body>
-  <div class="back-nav" role="navigation" aria-label="Page navigation">
+  <div class="back-nav" role="navigation" aria-label="Exit to main menu">
     <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
-      <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
-      <span class="back-nav__text">Back</span>
+      <span class="back-nav__icon" aria-hidden="true">&#8962;</span>
+      <span class="back-nav__text">Exit</span>
     </button>
   </div>
   <div class="lobby" id="lobby">

--- a/blackjack.html
+++ b/blackjack.html
@@ -277,10 +277,10 @@
 </style>
 </head>
 <body>
-  <div class="back-nav" role="navigation" aria-label="Page navigation">
+  <div class="back-nav" role="navigation" aria-label="Exit to main menu">
     <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
-      <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
-      <span class="back-nav__text">Back</span>
+      <span class="back-nav__icon" aria-hidden="true">&#8962;</span>
+      <span class="back-nav__text">Exit</span>
     </button>
   </div>
   <div class="lobby" id="lobby">

--- a/index.html
+++ b/index.html
@@ -443,12 +443,6 @@
     </style>
 </head>
 <body>
-    <div class="back-nav" role="navigation" aria-label="Page navigation">
-        <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
-            <span class="back-nav__icon" aria-hidden="true">&#8592;</span>
-            <span class="back-nav__text">Back</span>
-        </button>
-    </div>
     <main class="page">
         <section class="games-panel">
             <h1 class="panel-title">Game Vault</h1>


### PR DESCRIPTION
## Summary
- change the back navigation on game pages to an exit control that returns to the main menu
- remove the exit control from the main menu so it only appears on other pages

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68d7580cdbbc83258d0685dd76dbfb0d