### PR TITLE
Align blackjack player seats along bottom row

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -84,24 +84,33 @@
     left:50%;
     transform:translateX(-50%);
     width:92%;
-    height:62%;
     max-width:900px;
+    display:grid;
+    grid-template-columns:repeat(4, minmax(160px, 1fr));
+    gap:clamp(.6rem, 2vw, 1.4rem);
+    align-items:end;
+    justify-items:center;
+    padding:0 clamp(1.2rem, 4vw, 2.8rem) 2.5rem;
   }
 
   .seat-wrapper{
-    position:absolute;
+    position:relative;
     display:flex;
     justify-content:center;
     align-items:flex-end;
     min-height:190px;
-    width:180px;
-    transform:translate(-50%, 0);
-    transform-origin:bottom center;
+    width:100%;
+    max-width:210px;
+    transform:none;
+    transform-origin:initial;
   }
-  .seat-wrapper.slot-0{ left:18%; bottom:18%; }
-  .seat-wrapper.slot-1{ left:40%; bottom:8%; }
-  .seat-wrapper.slot-2{ left:60%; bottom:8%; }
-  .seat-wrapper.slot-3{ left:82%; bottom:18%; }
+  .seat-wrapper.slot-0,
+  .seat-wrapper.slot-1,
+  .seat-wrapper.slot-2,
+  .seat-wrapper.slot-3{
+    left:auto;
+    bottom:auto;
+  }
 
   .player-seat{
     position:relative;
@@ -199,12 +208,14 @@
   @media (max-width:720px){ .spot{ height:120px; } }
 
   @media (max-width:720px){
-    .lane.seats{ height:60%; max-width:100%; }
-    .seat-wrapper{ width:150px; min-height:150px; }
-    .seat-wrapper.slot-0{ left:20%; bottom:20%; }
-    .seat-wrapper.slot-1{ left:42%; bottom:10%; }
-    .seat-wrapper.slot-2{ left:58%; bottom:10%; }
-    .seat-wrapper.slot-3{ left:80%; bottom:20%; }
+    .lane.seats{
+      max-width:100%;
+      grid-template-columns:repeat(2, minmax(150px, 1fr));
+      justify-items:center;
+      gap:.9rem;
+      padding:0 1rem 2.5rem;
+    }
+    .seat-wrapper{ min-height:150px; max-width:180px; }
     .player-seat{ width:150px; padding:.5rem .35rem .7rem; }
   }
 


### PR DESCRIPTION
## Summary
- arrange player seat wrappers into a bottom-aligned grid so the bank/bet panels sit along the edge of the table
- add responsive tweaks so the four-player layout scales down cleanly on smaller viewports

## Testing
- Manual UI verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7571399388325bc5706d9778a9848