### PR TITLE
Refine blackjack table layout and betting area

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -18,8 +18,17 @@
   *{box-sizing:border-box}
   html,body{height:100%}
   body{
-    margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;
-    color:var(--text); background:#0b1020; display:grid; place-items:center;
+    margin:0;
+    font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial,sans-serif;
+    color:var(--text);
+    background:#0b1020;
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    justify-content:center;
+    min-height:100vh;
+    gap:clamp(18px,4vw,42px);
+    padding:clamp(32px,6vw,72px) 0 clamp(40px,8vw,96px);
   }
   .back-nav{
     position:fixed; top:18px; right:18px; z-index:10;
@@ -40,12 +49,15 @@
   }
   .back-nav__icon{font-size:1.05rem; line-height:1;}
   .table{
-    position:relative; width:min(1100px, 96vw);
+    position:relative;
+    width:min(1100px, 96vw);
     height:clamp(460px, 62vw, 640px);
     background: radial-gradient(140% 110% at 50% -20%, #2aa784 0, #1b7157 35%, var(--felt) 60%, var(--felt-dark) 98%);
     border-radius:0 0 520px 520px / 0 0 100% 100%;
     box-shadow: var(--shadow);
-    overflow:hidden; border:6px solid #0c3024;
+    overflow:hidden;
+    border:6px solid #0c3024;
+    margin-bottom:clamp(12px,3vw,28px);
   }
   .table::after{
     content:""; position:absolute; inset:20px 32px 26px;
@@ -93,7 +105,7 @@
     display:flex;
     justify-content:center;
     align-items:flex-end;
-    min-height:190px;
+    min-height:200px;
     width:180px;
     transform:translate(-50%, 0);
     transform-origin:bottom center;
@@ -107,25 +119,72 @@
     position:relative;
     width:180px;
     display:flex;
-    flex-direction:column;
-    align-items:center;
-    gap:.4rem;
-    padding:.6rem .4rem .8rem;
+    justify-content:center;
+    align-items:flex-end;
+    padding-bottom:24px;
+  }
+  .player-seat .spot{
+    width:100%;
+    height:190px;
+    display:flex;
+    justify-content:center;
+    align-items:flex-end;
+    position:relative;
+  }
+  .player-seat.active .spot::after{
+    content:"";
+    position:absolute;
+    inset:auto 18% 10px;
+    height:56px;
+    border-radius:50%;
+    background:rgba(255,209,59,.24);
+    filter:blur(0);
+    pointer-events:none;
+    box-shadow:0 0 48px rgba(255,209,59,.4);
+  }
+
+  .bets-rail{
+    width:min(1100px, 96vw);
+    background:linear-gradient(180deg, rgba(20,32,48,.94), rgba(10,16,30,.85));
+    border-radius:0 0 48px 48px;
+    border:1px solid rgba(255,255,255,.08);
+    box-shadow:0 24px 38px rgba(0,0,0,.45);
+    padding:clamp(18px,4vw,34px) clamp(22px,5vw,48px) clamp(20px,4vw,36px);
+    display:grid;
+    grid-template-columns:repeat(4, minmax(140px, 1fr));
+    gap:clamp(14px,2.8vw,32px);
+    backdrop-filter:blur(14px);
+    -webkit-backdrop-filter:blur(14px);
+  }
+
+  .bet-station{
+    display:grid;
+    justify-items:center;
+    gap:.45rem;
+    text-align:center;
+    padding:.55rem .4rem .75rem;
     border-radius:18px;
-    background:rgba(0,0,0,.2);
-    box-shadow:inset 0 0 0 1px rgba(255,255,255,.07);
-    backdrop-filter:blur(6px);
-    -webkit-backdrop-filter:blur(6px);
+    background:rgba(0,0,0,.28);
+    border:1px solid rgba(255,255,255,.08);
+    box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
+    min-height:150px;
   }
-  .player-seat .spot{ width:100%; }
-  .player-seat.active{
-    box-shadow:0 0 18px rgba(255,209,59,.35), inset 0 0 0 2px rgba(255,209,59,.6);
+
+  .bet-station.active{
+    border-color:rgba(255,209,59,.5);
+    box-shadow:0 0 20px rgba(255,209,59,.25), inset 0 0 0 1px rgba(255,209,59,.32);
   }
-  .player-seat.active .seat-name{
+
+  .bet-station.active .seat-name{
     color:var(--accent);
   }
 
+  .bet-station.empty{
+    opacity:.3;
+  }
+
   .seat-label{
+    width:100%;
     text-align:center;
     text-shadow:0 2px 8px rgba(0,0,0,.55);
     font-weight:600;
@@ -150,6 +209,7 @@
     margin-top:.35rem;
     flex-wrap:wrap;
     justify-content:center;
+    width:100%;
   }
   .bet-controls .bet-display{
     font-weight:700;
@@ -180,9 +240,17 @@
 
   /* Card */
   .card{
-    width:96px; height:136px; border-radius:12px; background:var(--card);
-    box-shadow: var(--shadow); position:absolute; transition: transform .4s ease, top .4s ease, left .4s ease, opacity .3s ease;
-    display:grid; place-items:center; overflow:hidden;
+    width:96px;
+    height:136px;
+    border-radius:12px;
+    background:var(--card);
+    box-shadow: var(--shadow);
+    position:relative;
+    transition:transform .3s ease, opacity .3s ease;
+    display:grid;
+    place-items:center;
+    overflow:hidden;
+    transform:translateY(calc(var(--card-raise, 0px) * -1)) rotate(var(--card-tilt, 0deg));
   }
   @media (max-width:720px){
     .card{ width:78px; height:112px; border-radius:10px; }
@@ -194,18 +262,39 @@
   }
 
   /* Spots where cards settle */
-  .spot{ position:relative; height:150px; display:flex; justify-content:center; }
-  .hand{ position:relative; min-height:100%; }
+  .spot{ position:relative; display:flex; justify-content:center; align-items:flex-end; }
+  .hand{
+    position:relative;
+    min-height:100%;
+    display:flex;
+    justify-content:center;
+    align-items:flex-end;
+    gap:clamp(.6rem,1.8vw,1.2rem);
+  }
   @media (max-width:720px){ .spot{ height:120px; } }
 
   @media (max-width:720px){
     .lane.seats{ height:60%; max-width:100%; }
-    .seat-wrapper{ width:150px; min-height:150px; }
+    .seat-wrapper{ width:150px; min-height:170px; }
     .seat-wrapper.slot-0{ left:20%; bottom:20%; }
     .seat-wrapper.slot-1{ left:42%; bottom:10%; }
     .seat-wrapper.slot-2{ left:58%; bottom:10%; }
     .seat-wrapper.slot-3{ left:80%; bottom:20%; }
-    .player-seat{ width:150px; padding:.5rem .35rem .7rem; }
+    .player-seat{ width:150px; padding-bottom:20px; }
+    .player-seat .spot{ height:160px; }
+    .bets-rail{
+      width:min(640px, 94vw);
+      grid-template-columns:repeat(auto-fit, minmax(140px, 1fr));
+      padding:clamp(16px,5vw,26px);
+      border-radius:28px;
+      gap:clamp(12px,4vw,20px);
+    }
+  }
+
+  @media (max-width:520px){
+    .bets-rail{
+      grid-template-columns:1fr;
+    }
   }
 
   /* Labels */
@@ -344,6 +433,8 @@
     </div>
   </div>
 
+  <div class="bets-rail" id="betsRail"></div>
+
   <script>
     function handleBack(event){
       if(event){
@@ -449,6 +540,7 @@
   /* ---------- DOM helpers ---------- */
   const dealerSpot = document.getElementById('dealerSpot');
   const playersLane = document.getElementById('playersLane');
+  const betsRail = document.getElementById('betsRail');
   const dealerTotal = document.getElementById('dealerTotal');
   const statusEl = document.getElementById('status');
   const turnIndicator = document.getElementById('turnIndicator');
@@ -599,32 +691,15 @@
     spot.appendChild(fan);
 
     if(!hand.length) return;
-
-    let cardWidth = 96;
-    let cardHeight = 136;
-
     hand.forEach((card, idx)=>{
       const el = document.createElement('div');
       el.className='card';
       const faceDown = hideHole && idx===1;
       el.innerHTML = faceDown ? '<div class="back"></div>' : renderSVG(card);
+      el.style.setProperty('--card-tilt', `${[-6,-3,3,6][idx%4]}deg`);
+      el.style.setProperty('--card-raise', `${Math.min(idx, 2) * 6}px`);
       fan.appendChild(el);
-
-      if(idx===0){
-        const rect = el.getBoundingClientRect();
-        if(rect.width) cardWidth = rect.width;
-        if(rect.height) cardHeight = rect.height;
-      }
-
-      el.style.left = `${20 + idx*28}px`;
-      el.style.top = `${6 + idx*2}px`;
-      el.style.transform = `translate(0,0) rotate(${[-3,-1,1,3][idx%4]}deg)`;
     });
-
-    const spread = (hand.length - 1) * 28;
-    const totalWidth = cardWidth + spread + 40;
-    fan.style.width = `${Math.max(totalWidth, cardWidth)}px`;
-    fan.style.height = `${cardHeight + 12}px`;
   }
 
   /* ---------- Firebase ---------- */
@@ -916,27 +991,52 @@
 
     const seatsToRender = entries.slice(0, SEAT_CLASSES.length);
     playersLane.innerHTML = '';
+    if(betsRail){
+      betsRail.innerHTML = '';
+    }
 
     SEAT_CLASSES.forEach((slotClass, index)=>{
       const wrapper = document.createElement('div');
       wrapper.className = `seat-wrapper ${slotClass}`;
       const entry = seatsToRender[index];
+      let id = null;
+      let info = null;
+      let hand = [];
+
       if(entry){
-        const [id, info] = entry;
+        [id, info] = entry;
         const seat = document.createElement('div');
         seat.className = 'player-seat';
         if(state.activePlayer === id){
           seat.classList.add('active');
         }
 
-        const confirmed = isBetConfirmed(id);
-
         const spot = document.createElement('div');
         spot.className = 'spot';
         seat.appendChild(spot);
 
-        const hand = Array.isArray(info?.hand) ? info.hand : [];
+        hand = Array.isArray(info?.hand) ? info.hand : [];
         renderHand(hand, spot);
+
+        wrapper.appendChild(seat);
+      }else{
+        wrapper.classList.add('empty');
+      }
+
+      playersLane.appendChild(wrapper);
+
+      if(!betsRail) return;
+
+      const station = document.createElement('div');
+      station.className = 'bet-station';
+
+      if(entry){
+        if(state.activePlayer === id){
+          station.classList.add('active');
+        }
+
+        const confirmed = isBetConfirmed(id);
+        const betValue = getBetForPlayer(id);
 
         const label = document.createElement('div');
         label.className = 'seat-label';
@@ -959,7 +1059,6 @@
         bankLabel.textContent = `Bank: ${bankValue}`;
         label.appendChild(bankLabel);
 
-        const betValue = getBetForPlayer(id);
         const betLabel = document.createElement('div');
         betLabel.className = 'seat-bet';
         betLabel.textContent = `Bet: ${betValue}`;
@@ -979,7 +1078,7 @@
         }
         label.appendChild(confirmLabel);
 
-        seat.appendChild(label);
+        station.appendChild(label);
 
         if(id === clientId){
           const controls = document.createElement('div');
@@ -1020,14 +1119,24 @@
           controls.appendChild(betDisplay);
           controls.appendChild(increaseBtn);
           controls.appendChild(confirmBtn);
-          seat.appendChild(controls);
+          station.appendChild(controls);
         }
-
-        wrapper.appendChild(seat);
       }else{
-        wrapper.classList.add('empty');
+        station.classList.add('empty');
+        const label = document.createElement('div');
+        label.className = 'seat-label';
+        const nameEl = document.createElement('div');
+        nameEl.className = 'seat-name';
+        nameEl.textContent = 'Open Seat';
+        label.appendChild(nameEl);
+        const totalEl = document.createElement('div');
+        totalEl.className = 'seat-total';
+        totalEl.textContent = 'Place your bet';
+        label.appendChild(totalEl);
+        station.appendChild(label);
       }
-      playersLane.appendChild(wrapper);
+
+      betsRail.appendChild(station);
     });
   }
 
@@ -1781,22 +1890,27 @@
   btnHit.addEventListener('click', ()=> !btnHit.classList.contains('muted') && playerHit());
   btnStand.addEventListener('click', ()=> !btnStand.classList.contains('muted') && playerStand());
 
+  function onBetControlClick(event){
+    const button = event.target.closest('[data-bet-action]');
+    if(!button) return;
+    if(button.dataset.playerId !== clientId) return;
+    if(tableState.state.phase !== 'waiting') return;
+    event.preventDefault();
+    const action = button.dataset.betAction;
+    if(action === 'increase'){
+      adjustMyBet(BET_STEP);
+    }else if(action === 'decrease'){
+      adjustMyBet(-BET_STEP);
+    }else if(action === 'confirm'){
+      confirmMyBet();
+    }
+  }
+
   if(playersLane){
-    playersLane.addEventListener('click', event=>{
-      const button = event.target.closest('[data-bet-action]');
-      if(!button) return;
-      if(button.dataset.playerId !== clientId) return;
-      if(tableState.state.phase !== 'waiting') return;
-      event.preventDefault();
-      const action = button.dataset.betAction;
-      if(action === 'increase'){
-        adjustMyBet(BET_STEP);
-      }else if(action === 'decrease'){
-        adjustMyBet(-BET_STEP);
-      }else if(action === 'confirm'){
-        confirmMyBet();
-      }
-    });
+    playersLane.addEventListener('click', onBetControlClick);
+  }
+  if(betsRail){
+    betsRail.addEventListener('click', onBetControlClick);
   }
 
   const initialCode = sanitizeRoomCode(window.location.hash.replace('#',''));


### PR DESCRIPTION
## Summary
- reshape the blackjack table layout so player cards live on the felt while bets sit in a dedicated rail beneath the half-circle
- fan rendered cards further apart and restyle seats to highlight the active player on the table surface
- move bet details/controls into the new rail and keep event handlers working for the relocated controls

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d759fec92c8325a98202eca05b77cb