### PR TITLE
Rework blackjack layout with separate betting tray

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -39,9 +39,16 @@
     outline:none;
   }
   .back-nav__icon{font-size:1.05rem; line-height:1;}
+  .table-wrapper{
+    width:min(1100px, 96vw);
+    display:flex;
+    flex-direction:column;
+    align-items:center;
+    gap:clamp(1.4rem, 3vw, 2.2rem);
+  }
   .table{
-    position:relative; width:min(1100px, 96vw);
-    height:clamp(460px, 62vw, 640px);
+    position:relative; width:100%;
+    height:clamp(420px, 58vw, 620px);
     background: radial-gradient(140% 110% at 50% -20%, #2aa784 0, #1b7157 35%, var(--felt) 60%, var(--felt-dark) 98%);
     border-radius:0 0 520px 520px / 0 0 100% 100%;
     box-shadow: var(--shadow);
@@ -78,19 +85,59 @@
   /* Lanes */
   .lane{ position:absolute; left:50%; transform:translateX(-50%); width:86%; }
   .dealer.lane{ top:8%; }
-  .lane.seats{
+  .lane.player-spots{
     position:absolute;
-    bottom:0;
+    bottom:22%;
     left:50%;
     transform:translateX(-50%);
-    width:92%;
-    max-width:900px;
+    width:82%;
+    max-width:820px;
+    display:flex;
+    justify-content:space-between;
+    align-items:flex-end;
+    gap:clamp(.8rem, 2.6vw, 1.6rem);
+    padding:0 clamp(1.2rem, 4vw, 2.4rem);
+    pointer-events:none;
+  }
+
+  .player-spot{
+    position:relative;
+    flex:1 1 0;
+    display:flex;
+    justify-content:center;
+    align-items:center;
+    min-height:clamp(140px, 20vw, 200px);
+    max-width:200px;
+  }
+  .player-spot::before{
+    content:"";
+    position:absolute;
+    inset:12px 20px 18px;
+    border:2px dashed rgba(255,255,255,.18);
+    border-radius:46% 46% 54% 54% / 48% 48% 52% 52%;
+    opacity:.45;
+    pointer-events:none;
+    z-index:0;
+  }
+  .player-spot.empty::before{ opacity:.16; }
+  .player-spot.slot-0,
+  .player-spot.slot-3{ transform:translateY(26px); }
+  .player-spot.slot-1,
+  .player-spot.slot-2{ transform:translateY(10px); }
+
+  .bet-tray{
+    width:100%;
+    background:rgba(11,16,30,.82);
+    border:1px solid rgba(255,255,255,.08);
+    border-radius:28px;
+    box-shadow:0 24px 40px rgba(0,0,0,.4);
+    padding:clamp(1.2rem, 3vw, 2rem);
     display:grid;
     grid-template-columns:repeat(4, minmax(160px, 1fr));
-    gap:clamp(.6rem, 2vw, 1.4rem);
-    align-items:end;
+    gap:clamp(.9rem, 2.6vw, 1.6rem);
     justify-items:center;
-    padding:0 clamp(1.2rem, 4vw, 2.8rem) 2.5rem;
+    backdrop-filter:blur(12px);
+    -webkit-backdrop-filter:blur(12px);
   }
 
   .seat-wrapper{
@@ -100,10 +147,13 @@
     align-items:flex-end;
     min-height:190px;
     width:100%;
-    max-width:210px;
-    transform:none;
-    transform-origin:initial;
+    max-width:220px;
   }
+  .seat-wrapper.empty{ opacity:.35; }
+  .seat-wrapper.slot-0,
+  .seat-wrapper.slot-3{ transform:translateY(-6px); }
+  .seat-wrapper.slot-1,
+  .seat-wrapper.slot-2{ transform:translateY(-14px); }
   .seat-wrapper.slot-0,
   .seat-wrapper.slot-1,
   .seat-wrapper.slot-2,
@@ -126,7 +176,6 @@
     backdrop-filter:blur(6px);
     -webkit-backdrop-filter:blur(6px);
   }
-  .player-seat .spot{ width:100%; }
   .player-seat.active{
     box-shadow:0 0 18px rgba(255,209,59,.35), inset 0 0 0 2px rgba(255,209,59,.6);
   }
@@ -190,8 +239,8 @@
   /* Card */
   .card{
     width:96px; height:136px; border-radius:12px; background:var(--card);
-    box-shadow: var(--shadow); position:absolute; transition: transform .4s ease, top .4s ease, left .4s ease, opacity .3s ease;
-    display:grid; place-items:center; overflow:hidden;
+    box-shadow: var(--shadow); position:relative; transition: transform .4s ease, opacity .3s ease;
+    display:grid; place-items:center; overflow:hidden; transform-origin:center bottom;
   }
   @media (max-width:720px){
     .card{ width:78px; height:112px; border-radius:10px; }
@@ -203,20 +252,35 @@
   }
 
   /* Spots where cards settle */
-  .spot{ position:relative; height:150px; display:flex; justify-content:center; }
-  .hand{ position:relative; min-height:100%; }
+  .spot{ position:relative; width:100%; height:100%; display:flex; justify-content:center; align-items:center; z-index:1; }
+  .hand{ position:relative; min-height:100%; display:flex; justify-content:center; align-items:flex-end; gap:clamp(.8rem, 2.4vw, 1.8rem); padding:0 12px; }
   @media (max-width:720px){ .spot{ height:120px; } }
 
   @media (max-width:720px){
-    .lane.seats{
-      max-width:100%;
-      grid-template-columns:repeat(2, minmax(150px, 1fr));
-      justify-items:center;
-      gap:.9rem;
-      padding:0 1rem 2.5rem;
+    .lane.player-spots{
+      width:90%;
+      bottom:24%;
+      gap:.8rem;
+      padding:0 1rem;
     }
-    .seat-wrapper{ min-height:150px; max-width:180px; }
+    .player-spot{ min-height:120px; max-width:160px; }
+    .bet-tray{ grid-template-columns:repeat(2, minmax(150px, 1fr)); }
+    .seat-wrapper{ min-height:150px; max-width:190px; }
+    .seat-wrapper.slot-0,
+    .seat-wrapper.slot-1,
+    .seat-wrapper.slot-2,
+    .seat-wrapper.slot-3{ transform:none; }
+    .player-spot.slot-0,
+    .player-spot.slot-1,
+    .player-spot.slot-2,
+    .player-spot.slot-3{ transform:none; }
     .player-seat{ width:150px; padding:.5rem .35rem .7rem; }
+  }
+
+  @media (max-width:520px){
+    .lane.player-spots{ bottom:26%; }
+    .player-spot{ max-width:140px; }
+    .bet-tray{ grid-template-columns:1fr; }
   }
 
   /* Labels */
@@ -231,7 +295,7 @@
   /* Controls */
   .controls{
     position:absolute; left:50%; transform:translateX(-50%);
-    bottom:3%; display:flex; gap:.6rem; z-index:3; flex-wrap:wrap; justify-content:center;
+    bottom:6%; display:flex; gap:.6rem; z-index:3; flex-wrap:wrap; justify-content:center;
   }
   button{
     appearance:none; border:0; border-radius:14px; padding:.9rem 1.2rem;
@@ -332,27 +396,31 @@
       </div>
     </div>
   </div>
-  <div class="table" id="table">
-    <header>
-      <div class="brand">BLACKJACK • FRIENDS LOUNGE</div>
-      <div class="spacer"></div>
-      <div class="turn-indicator hidden" id="turnIndicator">Waiting</div>
-      <div class="chip">Bank: <span id="bank">1000</span></div>
-    </header>
+  <div class="table-wrapper">
+    <div class="table" id="table">
+      <header>
+        <div class="brand">BLACKJACK • FRIENDS LOUNGE</div>
+        <div class="spacer"></div>
+        <div class="turn-indicator hidden" id="turnIndicator">Waiting</div>
+        <div class="chip">Bank: <span id="bank">1000</span></div>
+      </header>
 
-    <div class="label dealer">Dealer • <span class="total" id="dealerTotal">0</span></div>
-    <div class="lane dealer">
-      <div class="spot" id="dealerSpot"></div>
+      <div class="label dealer">Dealer • <span class="total" id="dealerTotal">0</span></div>
+      <div class="lane dealer">
+        <div class="spot" id="dealerSpot"></div>
+      </div>
+
+      <div class="lane player-spots" id="playerSpotsLane"></div>
+
+      <div class="status" id="status"></div>
+
+      <div class="controls" id="controls">
+        <button class="primary muted" id="btnHit">Hit</button>
+        <button class="ghost muted" id="btnStand">Stand</button>
+      </div>
     </div>
 
-    <div class="lane seats" id="playersLane"></div>
-
-    <div class="status" id="status"></div>
-
-    <div class="controls" id="controls">
-      <button class="primary muted" id="btnHit">Hit</button>
-      <button class="ghost muted" id="btnStand">Stand</button>
-    </div>
+    <div class="bet-tray" id="playersLane"></div>
   </div>
 
   <script>
@@ -460,6 +528,7 @@
   /* ---------- DOM helpers ---------- */
   const dealerSpot = document.getElementById('dealerSpot');
   const playersLane = document.getElementById('playersLane');
+  const playerSpotsLane = document.getElementById('playerSpotsLane');
   const dealerTotal = document.getElementById('dealerTotal');
   const statusEl = document.getElementById('status');
   const turnIndicator = document.getElementById('turnIndicator');
@@ -611,7 +680,6 @@
 
     if(!hand.length) return;
 
-    let cardWidth = 96;
     let cardHeight = 136;
 
     hand.forEach((card, idx)=>{
@@ -623,18 +691,16 @@
 
       if(idx===0){
         const rect = el.getBoundingClientRect();
-        if(rect.width) cardWidth = rect.width;
         if(rect.height) cardHeight = rect.height;
       }
 
-      el.style.left = `${20 + idx*28}px`;
-      el.style.top = `${6 + idx*2}px`;
-      el.style.transform = `translate(0,0) rotate(${[-3,-1,1,3][idx%4]}deg)`;
+      const angleSequence = [-6, -3, -1, 1, 3, 6];
+      const angle = angleSequence[Math.min(idx, angleSequence.length - 1)];
+      const center = (hand.length - 1) / 2;
+      const lift = Math.max(0, 10 - Math.abs(idx - center) * 6);
+      el.style.transform = `translateY(${-lift}px) rotate(${angle}deg)`;
     });
 
-    const spread = (hand.length - 1) * 28;
-    const totalWidth = cardWidth + spread + 40;
-    fan.style.width = `${Math.max(totalWidth, cardWidth)}px`;
     fan.style.height = `${cardHeight + 12}px`;
   }
 
@@ -911,7 +977,7 @@
   }
 
   function renderSeats(state){
-    if(!playersLane) return;
+    if(!playersLane || !playerSpotsLane) return;
     const entries = getSortedPlayerEntries();
     const myIndex = entries.findIndex(([id])=>id === clientId);
     if(myIndex === -1){
@@ -927,10 +993,17 @@
 
     const seatsToRender = entries.slice(0, SEAT_CLASSES.length);
     playersLane.innerHTML = '';
+    playerSpotsLane.innerHTML = '';
 
     SEAT_CLASSES.forEach((slotClass, index)=>{
       const wrapper = document.createElement('div');
       wrapper.className = `seat-wrapper ${slotClass}`;
+      const spotWrapper = document.createElement('div');
+      spotWrapper.className = `player-spot ${slotClass}`;
+      const spot = document.createElement('div');
+      spot.className = 'spot';
+      spotWrapper.appendChild(spot);
+      playerSpotsLane.appendChild(spotWrapper);
       const entry = seatsToRender[index];
       if(entry){
         const [id, info] = entry;
@@ -941,10 +1014,6 @@
         }
 
         const confirmed = isBetConfirmed(id);
-
-        const spot = document.createElement('div');
-        spot.className = 'spot';
-        seat.appendChild(spot);
 
         const hand = Array.isArray(info?.hand) ? info.hand : [];
         renderHand(hand, spot);
@@ -1037,6 +1106,7 @@
         wrapper.appendChild(seat);
       }else{
         wrapper.classList.add('empty');
+        spotWrapper.classList.add('empty');
       }
       playersLane.appendChild(wrapper);
     });


### PR DESCRIPTION
## Summary
- wrap the table in a new semi-circular surface with a dedicated player card lane and a separate bet tray underneath
- restyle player spots so cards fan across the felt while bet controls sit in a glassy rack below the table
- update the seat rendering logic to drive the new player spot lane and adjust card spacing for clearer separation

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d75d1afc2c83258654ce980161c7a9