### PR TITLE
Add account avatar dropdown to main page

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,178 @@
             line-height: 1;
         }
 
+        .top-actions {
+            position: fixed;
+            top: clamp(0.9rem, 2vw, 1.6rem);
+            left: clamp(0.9rem, 2vw, 1.6rem);
+            right: clamp(0.9rem, 2vw, 1.6rem);
+            display: flex;
+            justify-content: flex-end;
+            align-items: center;
+            flex-wrap: wrap;
+            gap: clamp(0.8rem, 2vw, 1.4rem);
+            z-index: 60;
+        }
+
+        .top-actions .back-nav {
+            position: static;
+            top: auto;
+            right: auto;
+            z-index: auto;
+        }
+
+        .sr-only {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+
+        .account-menu {
+            position: relative;
+            display: flex;
+            align-items: center;
+        }
+
+        .account-menu__trigger {
+            appearance: none;
+            border: none;
+            background: transparent;
+            padding: 0;
+            border-radius: 999px;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            box-shadow: 0 20px 35px rgba(5, 3, 17, 0.45);
+            transition: transform 0.2s ease, box-shadow 0.2s ease;
+        }
+
+        .account-menu__trigger:hover,
+        .account-menu__trigger:focus-visible {
+            transform: translateY(-1px);
+            box-shadow: 0 28px 45px rgba(5, 3, 17, 0.55);
+            outline: none;
+        }
+
+        .account-menu__avatar {
+            width: clamp(38px, 4vw, 44px);
+            height: clamp(38px, 4vw, 44px);
+            border-radius: 50%;
+            border: 1px solid rgba(147, 198, 255, 0.35);
+            background: linear-gradient(135deg, rgba(147, 198, 255, 0.35), rgba(247, 167, 218, 0.35));
+            color: var(--text-primary);
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 700;
+            font-size: 1rem;
+            letter-spacing: 0.04em;
+        }
+
+        .account-menu[data-state="signed-in"] .account-menu__avatar {
+            background: linear-gradient(135deg, var(--accent-blue), var(--accent-pink));
+            border-color: rgba(255, 255, 255, 0.45);
+            color: #140827;
+        }
+
+        .account-menu__dropdown {
+            position: absolute;
+            top: calc(100% + 0.8rem);
+            right: 0;
+            min-width: clamp(220px, 30vw, 260px);
+            padding: 1rem;
+            border-radius: var(--radius-lg);
+            background: linear-gradient(150deg, rgba(19, 12, 38, 0.95), rgba(8, 5, 20, 0.98));
+            border: 1px solid rgba(147, 198, 255, 0.22);
+            box-shadow: var(--shadow-strong);
+            opacity: 0;
+            transform: translateY(-6px);
+            pointer-events: none;
+            transition: opacity 0.2s ease, transform 0.2s ease;
+        }
+
+        .account-menu.is-open .account-menu__dropdown {
+            opacity: 1;
+            transform: translateY(0);
+            pointer-events: auto;
+        }
+
+        .account-menu__dropdown[hidden] {
+            display: none;
+        }
+
+        .account-menu__details {
+            display: flex;
+            flex-direction: column;
+            gap: 0.25rem;
+            margin-bottom: 0.75rem;
+        }
+
+        .account-menu__name {
+            font-weight: 600;
+            font-size: 1.05rem;
+        }
+
+        .account-menu__status {
+            font-size: 0.85rem;
+            color: var(--text-muted);
+        }
+
+        .account-menu__actions {
+            display: grid;
+            gap: 0.5rem;
+        }
+
+        .account-menu__action {
+            appearance: none;
+            border: 1px solid rgba(147, 198, 255, 0.28);
+            background: rgba(147, 198, 255, 0.12);
+            color: var(--text-primary);
+            border-radius: calc(var(--radius-sm) - 4px);
+            padding: 0.55rem 0.9rem;
+            font-size: 0.9rem;
+            font-weight: 600;
+            text-align: left;
+            cursor: pointer;
+            transition: border-color 0.2s ease, background 0.2s ease, transform 0.2s ease;
+        }
+
+        .account-menu__action:hover,
+        .account-menu__action:focus-visible {
+            border-color: rgba(247, 167, 218, 0.6);
+            background: rgba(147, 198, 255, 0.22);
+            transform: translateY(-1px);
+            outline: none;
+        }
+
+        .account-menu__action[data-account-action="signin"] {
+            background: linear-gradient(135deg, rgba(147, 198, 255, 0.28), rgba(247, 167, 218, 0.28));
+            border-color: rgba(147, 198, 255, 0.42);
+        }
+
+        .account-menu__action[data-account-action="signin"]:hover,
+        .account-menu__action[data-account-action="signin"]:focus-visible {
+            background: linear-gradient(135deg, rgba(147, 198, 255, 0.45), rgba(247, 167, 218, 0.45));
+            border-color: rgba(247, 167, 218, 0.7);
+        }
+
+        .account-menu__action[data-account-action="signout"] {
+            background: rgba(241, 118, 159, 0.12);
+            border-color: rgba(241, 118, 159, 0.35);
+        }
+
+        .account-menu__action[data-account-action="signout"]:hover,
+        .account-menu__action[data-account-action="signout"]:focus-visible {
+            background: rgba(241, 118, 159, 0.22);
+            border-color: rgba(241, 118, 159, 0.55);
+        }
+
         .page {
             width: min(1200px, 100%);
             display: grid;
@@ -435,6 +607,17 @@
                 padding: clamp(1.2rem, 6vw, 2rem);
             }
 
+            .top-actions {
+                top: clamp(0.7rem, 5vw, 1.2rem);
+                left: clamp(0.7rem, 5vw, 1.2rem);
+                right: clamp(0.7rem, 5vw, 1.2rem);
+                gap: 0.75rem;
+            }
+
+            .account-menu__dropdown {
+                min-width: min(260px, 82vw);
+            }
+
             .card-top {
                 flex-direction: column;
                 align-items: flex-start;
@@ -443,6 +626,54 @@
     </style>
 </head>
 <body>
+    <div class="top-actions">
+        <div class="back-nav" role="navigation" aria-label="Return home">
+            <button type="button" class="back-nav__button" data-home="index.html" onclick="handleBack(event)">
+                <span class="back-nav__icon" aria-hidden="true">&#8962;</span>
+                <span class="back-nav__text">Home</span>
+            </button>
+        </div>
+        <div class="account-menu" data-account-menu data-state="signed-out">
+            <button
+                type="button"
+                class="account-menu__trigger"
+                data-account-trigger
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="account-menu-dropdown"
+            >
+                <span class="account-menu__avatar" data-account-avatar>G</span>
+                <span class="sr-only">Open account menu</span>
+            </button>
+            <div
+                class="account-menu__dropdown"
+                data-account-dropdown
+                id="account-menu-dropdown"
+                role="menu"
+                aria-label="Account options"
+                hidden
+            >
+                <div class="account-menu__details">
+                    <span class="account-menu__name" data-account-name>Guest</span>
+                    <span class="account-menu__status" data-account-status>Signed out</span>
+                </div>
+                <div class="account-menu__actions">
+                    <button type="button" class="account-menu__action" data-account-action="signin" role="menuitem">
+                        Sign in
+                    </button>
+                    <button
+                        type="button"
+                        class="account-menu__action"
+                        data-account-action="signout"
+                        role="menuitem"
+                        hidden
+                    >
+                        Sign out
+                    </button>
+                </div>
+            </div>
+        </div>
+    </div>
     <main class="page">
         <section class="games-panel">
             <h1 class="panel-title">Game Vault</h1>
@@ -626,6 +857,236 @@
 
             window.location.href = home;
         }
+
+        (function setupAccountMenu() {
+            const menu = document.querySelector('[data-account-menu]');
+            if (!menu) {
+                return;
+            }
+
+            const trigger = menu.querySelector('[data-account-trigger]');
+            const dropdown = menu.querySelector('[data-account-dropdown]');
+            const avatar = menu.querySelector('[data-account-avatar]');
+            const nameEl = menu.querySelector('[data-account-name]');
+            const statusEl = menu.querySelector('[data-account-status]');
+            const signInButton = menu.querySelector('[data-account-action="signin"]');
+            const signOutButton = menu.querySelector('[data-account-action="signout"]');
+
+            if (!trigger || !dropdown || !avatar || !nameEl || !statusEl || !signInButton || !signOutButton) {
+                return;
+            }
+
+            const storageKey = 'ak-account-profile';
+            let storageAvailable = true;
+            let isOpen = false;
+            let account = null;
+
+            function normalizeName(value) {
+                if (typeof value !== 'string') {
+                    return '';
+                }
+
+                return value.replace(/\s+/g, ' ').trim();
+            }
+
+            function getInitial(name) {
+                const normalized = normalizeName(name);
+                if (!normalized) {
+                    return 'G';
+                }
+
+                return normalized.charAt(0).toUpperCase();
+            }
+
+            function updateUI() {
+                const isSignedIn = Boolean(account && account.name);
+                menu.dataset.state = isSignedIn ? 'signed-in' : 'signed-out';
+                avatar.textContent = isSignedIn ? getInitial(account.name) : 'G';
+                nameEl.textContent = isSignedIn ? account.name : 'Guest';
+
+                const statusText = isSignedIn ? 'Signed in' : 'Signed out';
+                statusEl.textContent = storageAvailable ? statusText : `${statusText} • not saved`;
+
+                signInButton.hidden = isSignedIn;
+                signOutButton.hidden = !isSignedIn;
+
+                const ariaLabel = isSignedIn
+                    ? `Open account menu for ${account.name}`
+                    : 'Open account menu. You are signed out.';
+                trigger.setAttribute('aria-label', ariaLabel);
+            }
+
+            function loadAccount() {
+                if (!storageAvailable) {
+                    return null;
+                }
+
+                try {
+                    const stored = window.localStorage.getItem(storageKey);
+                    if (!stored) {
+                        return null;
+                    }
+
+                    const parsed = JSON.parse(stored);
+                    if (parsed && typeof parsed === 'object' && 'name' in parsed) {
+                        const normalizedName = normalizeName(parsed.name);
+                        if (normalizedName) {
+                            return { name: normalizedName };
+                        }
+                    }
+                } catch (error) {
+                    storageAvailable = false;
+                    console.warn('Account state unavailable', error);
+                }
+
+                return null;
+            }
+
+            function persistAccount(value) {
+                if (!storageAvailable) {
+                    return;
+                }
+
+                try {
+                    if (value && value.name) {
+                        window.localStorage.setItem(storageKey, JSON.stringify({ name: value.name }));
+                    } else {
+                        window.localStorage.removeItem(storageKey);
+                    }
+                } catch (error) {
+                    storageAvailable = false;
+                    console.warn('Unable to persist account state', error);
+                    updateUI();
+                }
+            }
+
+            function closeMenu(options = {}) {
+                const { focusTrigger = false } = options;
+
+                if (!isOpen) {
+                    if (focusTrigger) {
+                        trigger.focus();
+                    }
+                    return;
+                }
+
+                isOpen = false;
+                menu.classList.remove('is-open');
+                dropdown.hidden = true;
+                trigger.setAttribute('aria-expanded', 'false');
+                document.removeEventListener('pointerdown', handlePointerDown, true);
+                document.removeEventListener('keydown', handleKeydown, true);
+
+                if (focusTrigger) {
+                    trigger.focus();
+                }
+            }
+
+            function openMenu() {
+                if (isOpen) {
+                    return;
+                }
+
+                isOpen = true;
+                dropdown.hidden = false;
+                menu.classList.add('is-open');
+                trigger.setAttribute('aria-expanded', 'true');
+
+                document.addEventListener('pointerdown', handlePointerDown, true);
+                document.addEventListener('keydown', handleKeydown, true);
+
+                const firstAction = dropdown.querySelector('[data-account-action]:not([hidden])');
+                if (firstAction instanceof HTMLElement) {
+                    window.requestAnimationFrame(() => {
+                        firstAction.focus();
+                    });
+                }
+            }
+
+            function handlePointerDown(event) {
+                if (!menu.contains(event.target)) {
+                    closeMenu();
+                }
+            }
+
+            function handleKeydown(event) {
+                if (!isOpen) {
+                    return;
+                }
+
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    closeMenu({ focusTrigger: true });
+                    return;
+                }
+
+                if (event.key === 'Tab') {
+                    const focusable = Array.from(
+                        dropdown.querySelectorAll('[data-account-action]:not([hidden])')
+                    );
+
+                    if (focusable.length === 0) {
+                        return;
+                    }
+
+                    const first = focusable[0];
+                    const last = focusable[focusable.length - 1];
+
+                    if (!event.shiftKey && document.activeElement === last) {
+                        event.preventDefault();
+                        first.focus();
+                    } else if (event.shiftKey && document.activeElement === first) {
+                        event.preventDefault();
+                        last.focus();
+                    }
+                }
+            }
+
+            trigger.addEventListener('click', () => {
+                if (isOpen) {
+                    closeMenu();
+                } else {
+                    openMenu();
+                }
+            });
+
+            trigger.addEventListener('keydown', (event) => {
+                if (event.key === 'ArrowDown') {
+                    event.preventDefault();
+                    openMenu();
+                }
+            });
+
+            signInButton.addEventListener('click', () => {
+                closeMenu();
+                const input = window.prompt('Enter your display name to sign in:', account?.name ?? '');
+                if (input === null) {
+                    trigger.focus();
+                    return;
+                }
+
+                const normalizedName = normalizeName(input);
+                if (!normalizedName) {
+                    trigger.focus();
+                    return;
+                }
+
+                account = { name: normalizedName };
+                persistAccount(account);
+                updateUI();
+                trigger.focus();
+            });
+
+            signOutButton.addEventListener('click', () => {
+                account = null;
+                persistAccount(account);
+                updateUI();
+                closeMenu({ focusTrigger: true });
+            });
+
+            account = loadAccount();
+            updateUI();
+        })();
     </script>
 
     <script type="module">


### PR DESCRIPTION
## Summary
- add a fixed top-right actions bar with the home button and an account bubble on the homepage
- implement dropdown styling and responsive tweaks for the account menu
- wire up JavaScript to manage accessibility, persistence, and simple sign-in/out prompts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d765aa4c548325a08251bacc29b967