### PR TITLE
Shrink and stack player cards

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -242,14 +242,14 @@
 
   /* Card */
   .card{
-    width:96px; height:136px; border-radius:12px; background:var(--card);
+    width:86px; height:124px; border-radius:11px; background:var(--card);
     box-shadow: var(--shadow); position:relative; transition: transform .4s ease, opacity .3s ease;
     display:grid; place-items:center; overflow:hidden; transform-origin:center bottom;
   }
   @media (max-width:720px){
-    .card{ width:78px; height:112px; border-radius:10px; }
+    .card{ width:70px; height:104px; border-radius:9px; }
   }
-  .card .svg{ width:94%; height:94%; }
+  .card .svg{ width:96%; height:96%; }
   .back{
     background:repeating-linear-gradient(45deg, #1d2740, #1d2740 10px, #2b3a66 10px, #2b3a66 20px);
     border:3px solid #e5e9f6; position:absolute; inset:0; border-radius:12px;
@@ -263,7 +263,7 @@
     display:flex;
     justify-content:center;
     align-items:flex-end;
-    gap:clamp(.45rem, 1.6vw, 1rem);
+    gap:0;
     padding:0 12px;
     overflow:visible;
   }
@@ -704,6 +704,21 @@
     spot.appendChild(fan);
     const playerSpot = spot.closest('.player-spot');
     const isPlayerFan = Boolean(playerSpot);
+    let fanAngle = 0;
+    if(playerSpot){
+      const slotFanAngles = {
+        'slot-0': -18,
+        'slot-1': -8,
+        'slot-2': 8,
+        'slot-3': 18
+      };
+      for(const cls of playerSpot.classList){
+        if(slotFanAngles.hasOwnProperty(cls)){
+          fanAngle = slotFanAngles[cls];
+          break;
+        }
+      }
+    }
 
     if(!hand.length) return;
 
@@ -721,23 +736,25 @@
         if(rect.height) cardHeight = rect.height;
       }
 
-      const angleSequence = [-6, -3, -1, 1, 3, 6];
-      const angle = angleSequence[Math.min(idx, angleSequence.length - 1)];
       const center = (hand.length - 1) / 2;
-      const lift = Math.max(0, 10 - Math.abs(idx - center) * 6);
+      const playerLift = Math.max(0, 6 - Math.abs(idx - center) * 3);
       if(isPlayerFan){
-        const spreadStep = 18 - Math.min(hand.length, 6);
-        const offset = (idx - center) * Math.max(10, spreadStep);
+        const spacing = Math.max(16, 28 - Math.min(hand.length, 6) * 2);
+        const offset = (idx - center) * spacing;
         const transforms = [];
         if(offset !== 0){
           transforms.push(`translateX(${offset}px)`);
         }
-        if(lift !== 0){
-          transforms.push(`translateY(${-lift}px)`);
+        if(playerLift !== 0){
+          transforms.push(`translateY(${-playerLift}px)`);
         }
-        transforms.push('rotate(0deg)');
+        transforms.push(`rotate(${-fanAngle}deg)`);
         el.style.transform = transforms.join(' ');
+        el.style.zIndex = String(10 + idx);
       }else{
+        const angleSequence = [-6, -3, -1, 1, 3, 6];
+        const angle = angleSequence[Math.min(idx, angleSequence.length - 1)];
+        const lift = Math.max(0, 10 - Math.abs(idx - center) * 6);
         el.style.transform = `translateY(${-lift}px) rotate(${angle}deg)`;
       }
     });


### PR DESCRIPTION
## Summary
- reduce card dimensions and tighten the hand container spacing so player cards look more proportional to the table
- overlap player cards while maintaining counter-rotation to mimic a real blackjack stack

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7687beb348325a417a8933c4ec09e