### PR TITLE
Add Grand War strategy game to arcade lineup

### DIFF
--- a/grand-war.html
+++ b/grand-war.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width,initial-scale=1" />
-<title>NA Conquest — ARIA ARCADE</title>
+<title>Grand War — ARIA ARCADE</title>
 <style>
   :root{
     --bg:#0b1020;

--- a/index.html
+++ b/index.html
@@ -851,13 +851,13 @@
                     <a class="cta" href="RatRace.html">Enter race</a>
                 </article>
 
-                <article class="project-card" data-status="reserved">
+                <article class="project-card" data-status="live">
                     <div class="card-top">
-                        <span class="status">Reserved</span>
-                        <span class="tag">Wildcard</span>
+                        <span class="status">Live</span>
+                        <span class="tag">Strategy</span>
                     </div>
-                    <h3>Mystery Slot</h3>
-                    <span class="cta disabled">Accepting ideas</span>
+                    <h3>Grand War</h3>
+                    <a class="cta" href="grand-war.html">Join battle</a>
                 </article>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- rename the Galcon America page to Grand War and update its title
- update the arcade card so Grand War appears as a live strategy game and links to the page

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79ca44acc83259aa6b3a1a5871343