### PR TITLE
Fill entire rat maze and scale down racers

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -160,13 +160,13 @@
   .rat-layer{ position:absolute; inset:0; pointer-events:none; z-index:2; }
   .rat{
     position:absolute;
-    width:160px;
-    height:150px;
+    width:132px;
+    height:118px;
     transform:translate(-9999px,-9999px);
     pointer-events:none;
   }
-  .rat-art{ width:160px; height:auto; transform-origin:50% 70%; }
-  .rat svg{ width:160px; height:auto; }
+  .rat-art{ width:132px; height:auto; transform-origin:50% 70%; }
+  .rat svg{ width:132px; height:auto; }
   .rat svg .tail{ animation:tail-sway 1.1s ease-in-out infinite; transform-origin:60px 92px; }
   .rat svg .body-group{ animation:body-bob .48s ease-in-out infinite; transform-origin:120px 90px; }
   .rat svg .ear{ animation:ear-flick 2.6s ease-in-out infinite; transform-origin:188px 56px; }
@@ -635,8 +635,8 @@ const trackViewport = document.getElementById('trackViewport');
 
 const VIEWBOX_WIDTH = 1200;
 const VIEWBOX_HEIGHT = 640;
-const MAZE_PATH = 'M 90 120 L 420 120 L 420 220 L 260 220 L 260 320 L 620 320 L 620 420 L 320 420 L 320 520 L 760 520 L 760 440 L 980 440 L 980 580 L 1120 580';
-const FINISH_LINE = { x: 1080, y1: 580, y2: 500 };
+const MAZE_PATH = 'M 80 80 L 1080 80 L 1080 160 L 200 160 L 200 220 L 1040 220 L 1040 300 L 260 300 L 260 360 L 960 360 L 960 440 L 160 440 L 160 520 L 900 520 L 900 600 L 120 600 L 120 620 L 1080 620';
+const FINISH_LINE = { x: 1080, y1: 640, y2: 540 };
 
 const laneCount = RAT_DATA.length;
 const laneOffsetStep = 32;
@@ -1353,7 +1353,7 @@ function startRace(setup){
   const byId = new Map((configuration?.rats || []).map(cfg => [cfg.id, cfg]));
   for(const r of rats){
     const cfg = byId.get(r.id) || {};
-    r.v = cfg.baseSpeed ?? (6 + Math.random()*2.4);
+    r.v = cfg.baseSpeed ?? (4.1 + Math.random()*1.6);
     r.baseSpeed = r.v;
     r.wobbleAmp = cfg.wobbleAmp ?? (0.5 + Math.random()*0.4);
     r.wobblePeriod = cfg.wobblePeriod ?? (180 + Math.random()*140);
@@ -1453,7 +1453,7 @@ function createRaceSetup(){
   return {
     rats: RAT_DATA.map(r=>({
       id: r.id,
-      baseSpeed: 6 + Math.random()*2.8,
+      baseSpeed: 4.1 + Math.random()*1.6,
       wobbleAmp: 0.5 + Math.random()*0.35,
       wobblePeriod: 180 + Math.random()*160,
       wobblePhase: Math.random()*Math.PI*2


### PR DESCRIPTION
## Summary
- redraw the maze path so it snakes across nearly the entire canvas and adjust the finish line to match the new endpoint
- shrink the rat sprites so they fit the tighter course spacing

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68d799b7996c8325b4662549f0ee4430