### PR TITLE
Center dealer cards at top of blackjack table

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -85,6 +85,10 @@
   /* Lanes */
   .lane{ position:absolute; left:50%; transform:translateX(-50%); width:86%; }
   .dealer.lane{ top:8%; }
+  .dealer.lane .spot{
+    justify-content:center;
+    align-items:flex-start;
+  }
   .lane.player-spots{
     position:absolute;
     bottom:22%;
@@ -737,8 +741,18 @@
 
     const stackHeight = cardHeight + (hand.length - 1) * verticalStep;
     const stackWidth = cardWidth + (hand.length - 1) * horizontalStep;
+    const isDealer = spot && (spot.id === 'dealerSpot' || spot.classList.contains('dealer-spot'));
+
     fan.style.minHeight = `${stackHeight}px`;
     fan.style.minWidth = `${stackWidth}px`;
+
+    if(isDealer){
+      fan.style.width = `${stackWidth}px`;
+      fan.style.margin = '0 auto';
+    }else{
+      fan.style.removeProperty('width');
+      fan.style.removeProperty('margin');
+    }
   }
 
   /* ---------- Firebase ---------- */


### PR DESCRIPTION
## Summary
- center the dealer lane spot and constrain the hand width so the cards sit at the top middle of the table
- adjust hand rendering to size dealer hands for centered alignment while leaving player hands unchanged

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d7a151369c8325b0af30e28d3a2389