### PR TITLE
Add banana download card to game vault

### DIFF
--- a/assets/banana.svg
+++ b/assets/banana.svg
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 200 200">
+  <title>Illustration of a ripe banana</title>
+  <defs>
+    <linearGradient id="bananaPeel" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#fff6a3" />
+      <stop offset="45%" stop-color="#ffe066" />
+      <stop offset="100%" stop-color="#f7b733" />
+    </linearGradient>
+    <radialGradient id="bananaShadow" cx="50%" cy="50%" r="55%">
+      <stop offset="0%" stop-color="rgba(0,0,0,0.25)" />
+      <stop offset="100%" stop-color="rgba(0,0,0,0)" />
+    </radialGradient>
+  </defs>
+  <ellipse cx="110" cy="150" rx="70" ry="20" fill="url(#bananaShadow)" />
+  <path
+    d="M30 40c15 90 70 120 130 120 5 0 6-6 2-8-28-16-50-52-53-88-1-10-1-20 1-30-7 1-16 5-28 12-17 11-34 13-46 10z"
+    fill="url(#bananaPeel)"
+    stroke="#d29922"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+  <path
+    d="M147 147c7 4 17 6 27 5"
+    fill="none"
+    stroke="#c8831f"
+    stroke-width="6"
+    stroke-linecap="round"
+  />
+  <path
+    d="M106 36c-4-4-6-8-6-12 0-6 4-10 10-10 4 0 8 2 10 6 3 4 4 9 4 15"
+    fill="none"
+    stroke="#6a4b1c"
+    stroke-width="6"
+    stroke-linecap="round"
+    stroke-linejoin="round"
+  />
+</svg>

--- a/index.html
+++ b/index.html
@@ -736,6 +736,9 @@
             color: #110720;
             background: linear-gradient(135deg, var(--accent-blue), var(--accent-pink));
             box-shadow: 0 18px 32px rgba(147, 198, 255, 0.28);
+            border: none;
+            cursor: pointer;
+            font-family: inherit;
         }
 
         .cta:hover,
@@ -911,6 +914,15 @@
                     <h3>Grand War</h3>
                     <a class="cta" href="grand-war.html">Join battle</a>
                 </article>
+
+                <article class="project-card" data-status="live">
+                    <div class="card-top">
+                        <span class="status">Live</span>
+                        <span class="tag">Download</span>
+                    </div>
+                    <h3>Banana</h3>
+                    <button class="cta" type="button" data-download-banana>Download banana</button>
+                </article>
             </div>
         </section>
 
@@ -1070,6 +1082,51 @@
 
             window.location.href = home;
         }
+
+        (function setupBananaDownload() {
+            const button = document.querySelector('[data-download-banana]');
+            if (!(button instanceof HTMLButtonElement)) {
+                return;
+            }
+
+            const defaultLabel = button.textContent?.trim() || 'Download banana';
+            const downloadUrl = 'assets/banana.svg';
+            const downloadName = 'banana.svg';
+
+            button.addEventListener('click', async () => {
+                const restoreLabel = () => {
+                    button.textContent = defaultLabel;
+                    button.disabled = false;
+                };
+
+                button.disabled = true;
+                button.textContent = 'Preparing banana…';
+
+                try {
+                    const response = await fetch(downloadUrl, { cache: 'no-store' });
+                    if (!response.ok) {
+                        throw new Error(`Request failed with status ${response.status}`);
+                    }
+
+                    const blob = await response.blob();
+                    const href = URL.createObjectURL(blob);
+                    const anchor = document.createElement('a');
+                    anchor.href = href;
+                    anchor.download = downloadName;
+                    document.body.appendChild(anchor);
+                    anchor.click();
+                    anchor.remove();
+                    URL.revokeObjectURL(href);
+
+                    button.textContent = 'Banana ready!';
+                    window.setTimeout(restoreLabel, 1200);
+                } catch (error) {
+                    console.error('Unable to download banana image', error);
+                    button.textContent = 'Download failed. Try again';
+                    window.setTimeout(restoreLabel, 1800);
+                }
+            });
+        })();
 
         (function setupAccountMenu() {
             const menu = document.querySelector('[data-account-menu]');


### PR DESCRIPTION
## Summary
- add a Banana project card that offers a banana download button
- ensure CTA styling works for button elements and wire up download behavior
- include a bespoke banana SVG asset for the download

## Testing
- Manual download tested in browser

------
https://chatgpt.com/codex/tasks/task_e_68d7a32d93d48325a22320e88522670b