### PR TITLE
Extend blackjack result display times

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -637,6 +637,7 @@
   const MIN_BET = 10;
   const MAX_BET = 90;
   const BET_STEP = 10;
+  const ROUND_RESULT_DISPLAY_MS = 3000;
   const LAST_BET_STORAGE_KEY = 'blackjackLastConfirmedBet';
   const AUTO_BET_STORAGE_KEY = 'blackjackAutoBetEnabled';
   let cachedLastConfirmedBet = null;
@@ -1571,7 +1572,7 @@
     tableState.state.confirmedBets = {};
 
     const sharedMessage = multiplePlayers ? 'Round complete' : (myMessage || 'Round complete');
-    const duration = multiplePlayers ? 1400 : 1500;
+    const duration = ROUND_RESULT_DISPLAY_MS;
     tableState.state.status = sharedMessage;
     tableState.state.statusUntil = Date.now() + duration;
     if(multiplePlayers && myMessage){
@@ -1712,7 +1713,7 @@
       const bustMsgName = me.name === 'You'
         ? `You bust -${bet}`
         : `${me.name || 'Player'} busts -${bet}`;
-      shareStatus(bustMsgName, 1500);
+      shareStatus(bustMsgName, ROUND_RESULT_DISPLAY_MS);
       const hasNext = finishTurn(clientId);
       commitRound();
       renderTable();


### PR DESCRIPTION
## Summary
- add a shared constant for blackjack round result display duration
- show bust and round-complete statuses for three seconds to keep the results visible

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d83544f1dc8325a7894d77da3f0e64