### PR TITLE
Fix Rat Race layout stretching

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -60,6 +60,7 @@
     gap:24px;
     grid-template-columns:minmax(0,2.15fr) minmax(0,1fr);
     grid-template-rows:minmax(460px,1fr) auto;
+    align-items:start;
     grid-template-areas:
       "track info"
       "bets bets";
@@ -87,6 +88,7 @@
     border:1px solid rgba(255,255,255,.06);
     box-shadow:inset 0 0 0 1px rgba(255,255,255,.04);
     overflow:hidden;
+    align-self:start;
     background:
       radial-gradient(160% 140% at 50% -30%, rgba(255,232,189,.18) 0%, rgba(141,86,40,.38) 55%, rgba(63,36,15,.88) 100%),
       linear-gradient(180deg, #b67a46 0%, #7f4f2c 82%);
@@ -150,7 +152,7 @@
   .info-panel{ grid-area:info; display:flex; flex-direction:column; gap:18px; }
   .info-panel .summaryGrid{ flex:1; }
   .bets-panel{ grid-area:bets; }
-  .info-panel.panel{ padding:24px; height:100%; }
+  .info-panel.panel{ padding:24px; align-self:start; }
   .bets-panel.panel{ padding:24px; }
   @media (max-width:720px){
     .info-panel.panel,


### PR DESCRIPTION
## Summary
- prevent the board grid from stretching its children so the track keeps its natural height
- let the track card and info panel align to the top so their content drives sizing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d8ce479d5c8325a7fa3ca6496d539e