### PR TITLE
Delay dealer play after final player stands

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -1759,10 +1759,22 @@
     tableState.state.status = '';
     tableState.state.statusUntil = 0;
     const hasNext = finishTurn(clientId);
+    if(!hasNext){
+      tableState.state.phase = 'dealer';
+      tableState.state.hideDealerHole = false;
+      shareStatus("Dealer revealing…", ROUND_RESULT_DISPLAY_MS);
+    }
     commitRound();
     renderTable();
     if(!hasNext){
-      dealerPlay();
+      scheduleRoundAdvance(()=>{
+        if(tableState.state.phase !== 'dealer') return;
+        tableState.state.status = '';
+        tableState.state.statusUntil = 0;
+        commitRound();
+        renderTable();
+        dealerPlay();
+      }, ROUND_RESULT_DISPLAY_MS);
     }
   }
 


### PR DESCRIPTION
## Summary
- delay the dealer's turn until after a reveal pause when the last player stands
- surface a short shared status while revealing the dealer's hole card before play resumes
- validate the table phase before invoking dealerPlay to keep multiplayer tables in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d8ee2f56b88325a820c43c256410f1