### PR TITLE
Add structured multiplayer lobby with player slots

### DIFF
--- a/ForFriends.html
+++ b/ForFriends.html
@@ -21,6 +21,16 @@
     button:disabled{opacity:.6;cursor:not-allowed}
     .tag{display:inline-flex;align-items:center;gap:6px;padding:6px 10px;border-radius:999px;border:1px solid #22304f;background:#0d162b;color:var(--muted);font-size:.9rem}
     .grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:14px}
+    .slots{grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:14px}
+    .lobby-code{display:flex;align-items:center;justify-content:space-between;flex-wrap:wrap;gap:10px;margin-bottom:14px}
+    .lobby-code .code{font-size:1.3rem;letter-spacing:.08em;padding:6px 12px}
+    .player-slot{display:flex;flex-direction:column;gap:8px;min-height:120px;border-radius:14px;border:1px dashed #22304f;background:rgba(13,22,43,.55);transition:border-color .2s,background .2s}
+    .player-slot.filled{border-style:solid;border-color:#2f68ff33;background:rgba(26,42,76,.75)}
+    .player-slot.empty{opacity:.75}
+    .slot-label{font-size:.82rem;color:var(--muted);text-transform:uppercase;letter-spacing:.08em}
+    .slot-name{font-size:1.15rem;font-weight:600}
+    .slot-meta{font-size:.9rem;color:var(--muted)}
+    .slot-meta .tag{margin-left:6px}
     .list{display:flex;flex-wrap:wrap;gap:10px}
     .muted{color:var(--muted)}
     .center{text-align:center}
@@ -118,8 +128,11 @@
         <h2 class="big">Lobby</h2>
         <span id="hostBadge" class="pill hidden">You are the host</span>
       </div>
-      <p>Share room code <span class="code" id="roomCode2"></span> or send the invite link.</p>
-      <div class="grid" id="playersList"></div>
+      <div class="lobby-code">
+        <p style="margin:0">Share this room code with friends:</p>
+        <span class="code" id="roomCode2"></span>
+      </div>
+      <div class="grid slots" id="playersList"></div>
       <div class="hr"></div>
       <div class="row">
         <button id="startBtn" class="primary hidden">Start Game</button>
@@ -262,6 +275,7 @@
     ];
 
     const STATE = { lobby: 'lobby', collect: 'collect', guess: 'guess', results: 'results' };
+    const MAX_PLAYERS = 8;
 
     let me = { uid:null, name:null, room:null, isHost:false };
     let gameDocUnsub = null; let playersUnsub = null; let guessesUnsub = null;
@@ -321,6 +335,8 @@
       const ref = roomRef(code); const snap = await getDoc(ref);
       if(!snap.exists()) return alert('Room not found');
       const data = snap.data(); if(data.state!==STATE.lobby) return alert('Game already started');
+      const existingPlayers = await getDocs(collection(db,'games', code, 'players'));
+      if(existingPlayers.size >= MAX_PLAYERS) return alert('Room is full');
       me.name = name; me.room = code; me.isHost = (data.hostId===me.uid);
       await setDoc(playerRef(code, me.uid), { name, joinedAt: serverTimestamp(), score:0, isHost: me.isHost, submitted:false, answers:{} });
       postJoin();
@@ -398,13 +414,32 @@
     // =====================
     function renderPlayers(players){
       ui.playersList.innerHTML = '';
-      players.forEach(p=>{
-        const el = document.createElement('div'); el.className='card pad';
-        el.innerHTML = `<div class="row" style="justify-content:space-between"><div><b>${p.name}</b></div><span class="muted">${p.isHost?'Host':'Player'}</span></div>`;
+      const totalPlayers = players.length;
+      for(let i=0;i<MAX_PLAYERS;i++){
+        const p = players[i];
+        const el = document.createElement('div');
+        el.className = 'player-slot card pad';
+        el.classList.add(p ? 'filled' : 'empty');
+        if(p){
+          const badges = [];
+          if(p.isHost) badges.push('Host');
+          if(p.id === me.uid) badges.push('You');
+          el.innerHTML = `
+            <div class="slot-label">Slot ${i+1}</div>
+            <div class="slot-name">${p.name}</div>
+            <div class="slot-meta">${badges.length ? badges.join(' • ') : 'Ready to play'}</div>
+          `;
+        } else {
+          el.innerHTML = `
+            <div class="slot-label">Slot ${i+1}</div>
+            <div class="slot-name muted">Waiting for player…</div>
+            <div class="slot-meta muted">Share the code to join</div>
+          `;
+        }
         ui.playersList.appendChild(el);
-      });
+      }
       // host start enabled only if 2+ players
-      if(me.isHost){ ui.startBtn.disabled = players.length<2; }
+      if(me.isHost){ ui.startBtn.disabled = totalPlayers<2; }
     }
 
     ui.startBtn.onclick = async ()=>{

--- a/ForFriends.html
+++ b/ForFriends.html
@@ -110,7 +110,6 @@
     <div class="wrap row" style="justify-content:space-between">
       <div class="row" style="gap:10px">
         <strong>Know Your Friends</strong>
-        <span class="tag">Firebase · Multiplayer</span>
         <span id="youTag" class="tag hidden">You: <span id="youName"></span></span>
         <span id="roomTag" class="tag hidden">Room: <span id="roomCode"></span></span>
       </div>
@@ -135,7 +134,7 @@
       <div class="grid slots" id="playersList"></div>
       <div class="hr"></div>
       <div class="row">
-        <button id="startBtn" class="primary hidden">Start Game</button>
+        <button id="startBtn" class="primary">Start Game</button>
         <span class="muted">All players answer the same 3 questions.</span>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- redesign the multiplayer lobby to surface the room code and eight player slots
- show placeholders for open slots and tag host/you badges for joined players
- prevent joining rooms that are already full to enforce the eight-player limit

## Testing
- No automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d8eeee1584832598a7c7a6bf73e4b4