### PR TITLE
Adjust rat race sprite and track proportions

### DIFF
--- a/RatRace.html
+++ b/RatRace.html
@@ -163,13 +163,13 @@
   .rat-layer{ position:absolute; inset:0; pointer-events:none; z-index:2; }
   .rat{
     position:absolute;
-    width:132px;
-    height:118px;
+    width:116px;
+    height:104px;
     transform:translate(-9999px,-9999px);
     pointer-events:none;
   }
-  .rat-art{ width:132px; height:auto; transform-origin:50% 70%; }
-  .rat svg{ width:132px; height:auto; }
+  .rat-art{ width:116px; height:auto; transform-origin:50% 70%; }
+  .rat svg{ width:116px; height:auto; }
   .rat svg .tail{ animation:tail-sway 1.1s ease-in-out infinite; transform-origin:60px 92px; }
   .rat svg .body-group{ animation:body-bob .48s ease-in-out infinite; transform-origin:120px 90px; }
   .rat svg .ear{ animation:ear-flick 2.6s ease-in-out infinite; transform-origin:188px 56px; }
@@ -186,7 +186,7 @@
     position:absolute;
     bottom:100%;
     left:50%;
-    transform:translate(-50%, -12px);
+    transform:translate(-50%, -10px);
     background:rgba(18,28,45,.78);
     padding:.18rem .7rem;
     font-size:.78rem;
@@ -208,24 +208,24 @@
   }
   .track-border{
     stroke:url(#trackEdge);
-    stroke-width:190;
+    stroke-width:168;
     opacity:.8;
   }
   .track-fill{
     stroke:url(#trackFill);
-    stroke-width:150;
+    stroke-width:132;
     filter:drop-shadow(0 26px 46px rgba(0,0,0,.45));
   }
   .track-glow{
     stroke:url(#trackGlow);
-    stroke-width:190;
+    stroke-width:172;
     opacity:.25;
     filter:blur(18px);
   }
   .track-texture{
     stroke:rgba(255,244,222,.18);
     stroke-width:10;
-    stroke-dasharray:28 36;
+    stroke-dasharray:24 32;
     stroke-linecap:round;
     opacity:.55;
   }
@@ -642,7 +642,7 @@ const MAZE_PATH = 'M 80 80 L 1080 80 L 1080 160 L 200 160 L 200 220 L 1040 220 L
 const FINISH_LINE = { x: 1080, y1: 640, y2: 540 };
 
 const laneCount = RAT_DATA.length;
-const laneOffsetStep = 32;
+const laneOffsetStep = 26;
 function buildTrackSvg(){
   if(!trackSvg) return;
 
@@ -712,8 +712,8 @@ const rats = RAT_DATA.map((r, index) => {
 
   const pathEl = lanePathMap.get(r.id);
   const pathLength = pathEl?.getTotalLength?.() || 1;
-  const halfWidth = el.offsetWidth / 2 || 80;
-  const halfHeight = el.offsetHeight / 2 || 60;
+  const halfWidth = el.offsetWidth / 2 || 58;
+  const halfHeight = el.offsetHeight / 2 || 52;
 
   const laneOffset = (index - (laneCount - 1) / 2) * laneOffsetStep;
 
@@ -746,7 +746,11 @@ function positionRat(r, distance=0){
   const ny = Math.cos(angle);
   const offsetX = pos.x + nx * laneOffset;
   const offsetY = pos.y + ny * laneOffset;
-  r.el.style.transform = `translate(${offsetX - (r.halfWidth||80)}px, ${offsetY - (r.halfHeight||60)}px)`;
+  const halfWidth = r.el.offsetWidth ? r.el.offsetWidth / 2 : (r.halfWidth || 58);
+  const halfHeight = r.el.offsetHeight ? r.el.offsetHeight / 2 : (r.halfHeight || 52);
+  r.halfWidth = halfWidth;
+  r.halfHeight = halfHeight;
+  r.el.style.transform = `translate(${offsetX - halfWidth}px, ${offsetY - halfHeight}px)`;
   r.art.style.transform = `rotate(${angle}rad)`;
 }
 


### PR DESCRIPTION
## Summary
- reduce rat sprite dimensions and adjust the attached name tag offset to keep artwork proportional
- shrink the track stroke widths and tweak the texture dash array to match the slimmer layout
- update lane spacing constants and centering logic so rats stay aligned after resizing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e335523684832982f8a206fcac2afb