### PR TITLE
Fix natural blackjack auto-stand logic

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -1590,12 +1590,23 @@
     tableState.state.statusUntil = Date.now() + duration;
   }
 
+  function isNaturalBlackjack(hand){
+    if(!Array.isArray(hand) || hand.length !== 2) return false;
+    const [first, second] = hand;
+    const firstRank = first && first.rank;
+    const secondRank = second && second.rank;
+    return (
+      (firstRank === 'A' && cardValue(second) === 10) ||
+      (secondRank === 'A' && cardValue(first) === 10)
+    );
+  }
+
   function checkAutoBlackjack(){
     if(tableState.state.phase !== 'player' || tableState.state.activePlayer !== clientId) return;
     const me = getPlayerEntry();
     if(me.roundResult === 'blackjack') return;
     const hand = me.hand || [];
-    if(handValue(hand) !== 21) return;
+    if(!isNaturalBlackjack(hand)) return;
     applyBlackjackForCurrent();
   }
 


### PR DESCRIPTION
## Summary
- add a helper that detects a natural blackjack from the opening two cards
- ensure the auto-blackjack shortcut only fires for a natural blackjack so later 21s continue normal play

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e33614d4308329b0dad82ccfc1f186