### PR TITLE
Keep blackjack auto bet toggle responsive between rounds

### DIFF
--- a/blackjack.html
+++ b/blackjack.html
@@ -719,6 +719,7 @@
   const MAX_BET = 90;
   const BET_STEP = 10;
   const ROUND_RESULT_DISPLAY_MS = 3000;
+  const AUTO_ROUND_GRACE_MS = 140;
   const TABLE_PHASES = Object.freeze({
     WAITING: 'waiting',
     PLAYER: 'player',
@@ -1475,7 +1476,7 @@
           autoCheckbox.dataset.playerId = id;
           const autoBetActive = AUTO_BET_FEATURE_ENABLED && isAutoBetEnabled();
           autoCheckbox.checked = autoBetActive;
-          const autoCheckboxDisabled = !AUTO_BET_FEATURE_ENABLED || !canAdjustBet;
+          const autoCheckboxDisabled = !AUTO_BET_FEATURE_ENABLED;
           autoCheckbox.disabled = autoCheckboxDisabled;
           const autoText = document.createElement('span');
           autoText.className = 'auto-bet-label';
@@ -1487,10 +1488,14 @@
           autoToggle.classList.toggle('active', autoBetActive);
           if(autoCheckboxDisabled){
             autoToggle.classList.add('muted');
-            autoToggle.title = 'Auto Bet can only be changed during the betting phase';
+            autoToggle.title = 'Auto Bet is unavailable';
           }else{
             autoToggle.classList.remove('muted');
-            autoToggle.removeAttribute('title');
+            if(canAdjustBet){
+              autoToggle.removeAttribute('title');
+            }else{
+              autoToggle.title = 'Changes apply to the next betting phase';
+            }
           }
 
           const confirmBtn = document.createElement('button');
@@ -1612,6 +1617,8 @@
   }
 
   let autoBlackjackTimer = null;
+  let autoRoundActionTimer = null;
+  let lastRenderedPhase = null;
   let roundTransitionTimer = null;
 
   function clearRoundTransitionTimer(){
@@ -1690,9 +1697,35 @@
     startDeal();
   }
 
+  function clearAutoRoundActionTimer(){
+    if(autoRoundActionTimer){
+      clearTimeout(autoRoundActionTimer);
+      autoRoundActionTimer = null;
+    }
+  }
+
+  function scheduleAutoRoundActions(){
+    clearAutoRoundActionTimer();
+    autoRoundActionTimer = setTimeout(()=>{
+      autoRoundActionTimer = null;
+      if(tableState.state.phase !== TABLE_PHASES.WAITING) return;
+      maybeApplyAutoBet();
+      maybeStartAutoDeal();
+    }, AUTO_ROUND_GRACE_MS);
+  }
+
   function renderTable(){
     const state = tableState.state || defaultState;
     const phase = typeof state.phase === 'string' ? state.phase : TABLE_PHASES.WAITING;
+    const previousPhase = lastRenderedPhase;
+    if(previousPhase !== phase){
+      if(phase === TABLE_PHASES.WAITING){
+        scheduleAutoRoundActions();
+      }else{
+        clearAutoRoundActionTimer();
+      }
+    }
+    lastRenderedPhase = phase;
     let me = tableState.players[clientId];
     if(!me){
       me = getPlayerEntry();
@@ -1759,7 +1792,7 @@
       turnIndicator.classList.add('hidden');
     }
 
-    if(phase === TABLE_PHASES.WAITING){
+    if(phase === TABLE_PHASES.WAITING && !autoRoundActionTimer && previousPhase === TABLE_PHASES.WAITING){
       maybeApplyAutoBet();
       maybeStartAutoDeal();
     }
@@ -2037,6 +2070,7 @@
 
   function startDeal(){
     if(tableState.state.phase !== TABLE_PHASES.WAITING || !isMyTurn()) return;
+    clearAutoRoundActionTimer();
     ensureShoe();
 
     const players = tableState.players || {};
@@ -2570,11 +2604,18 @@
       if(!control) return;
       if(control.dataset.playerId !== clientId) return;
       if(control.dataset.betAction !== 'auto-toggle') return;
-      if(tableState.state.phase !== TABLE_PHASES.WAITING) return;
       const checked = !!event.target.checked;
       setAutoBetEnabled(checked);
-      if(checked){
-        applyAutoBet();
+      const phase = tableState.state.phase;
+      if(phase === TABLE_PHASES.WAITING){
+        if(checked){
+          applyAutoBet();
+        }else{
+          setBetConfirmed(clientId, false);
+          scheduleAutoRoundActions();
+          commitRound({ includeDealer:false, includePlayer:false, includeShoe:false, includeState:true });
+          renderTable();
+        }
       }else{
         renderTable();
       }


### PR DESCRIPTION
## Summary
- keep the auto bet toggle interactive after betting locks and update its messaging
- let players change the auto bet preference during any phase, clearing confirmations when disabling during betting
- add a grace timer before reapplying auto bet or auto-dealing to ensure players can opt out between rounds

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68e3501458208329ae7e2de3fc8cb00a