### PR TITLE
Add Matthew Quiz game card to games page

### DIFF
--- a/games.html
+++ b/games.html
@@ -85,6 +85,12 @@
                     Race the timer, lock letters, and keep the category streak alive in this fast party classic.
                 </p>
             </a>
+            <a class="category-card" href="Matthew%20Quiz">
+                <span class="category-card__title">Matthew Quiz</span>
+                <p class="category-card__description">
+                    Start Matthew Quiz instantly and jump right into room-code trivia gameplay.
+                </p>
+            </a>
         </section>
     </main>
     <script>


### PR DESCRIPTION
### Motivation
- Add a visible game card so players can click a box on the Games page to launch the new Matthew Quiz (room-code trivia) experience.

### Description
- Inserted a new `<a class="category-card" href="Matthew%20Quiz">` entry into the games grid in `games.html` with the title "Matthew Quiz" and a short descriptive copy.

### Testing
- Verified the target file exists with `test -f 'Matthew Quiz'` and performed automated verification by serving the site with `python3 -m http.server 4173 --bind 0.0.0.0` and capturing a Playwright screenshot of `http://127.0.0.1:4173/games.html`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86a06c32c8329a10cf6807d1a6643)