### PR TITLE
Add Firebase project config to Matthew Quiz

### DIFF
--- a/Matthew Quiz
+++ b/Matthew Quiz
@@ -342,12 +342,14 @@
     // 1) PUT YOUR FIREBASE CONFIG HERE
     // =========================
     const firebaseConfig = {
-      apiKey: "PASTE_YOURS",
-      authDomain: "PASTE_YOURS",
-      projectId: "PASTE_YOURS",
-      storageBucket: "PASTE_YOURS",
-      messagingSenderId: "PASTE_YOURS",
-      appId: "PASTE_YOURS"
+      apiKey: "AIzaSyDRniZatGeylxphjHQadYjucOcirNBRIdk",
+      authDomain: "multiplayer-640ec.firebaseapp.com",
+      databaseURL: "https://multiplayer-640ec-default-rtdb.firebaseio.com",
+      projectId: "multiplayer-640ec",
+      storageBucket: "multiplayer-640ec.firebasestorage.app",
+      messagingSenderId: "94914236381",
+      appId: "1:94914236381:web:55ab00cc690140180cf034",
+      measurementId: "G-V43J1S8RGF"
     };
 
     const app = initializeApp(firebaseConfig);


### PR DESCRIPTION
### Motivation
- Enable multiplayer functionality by wiring the quiz to the intended Firebase project so real-time room and player data are stored in the provided backend.

### Description
- Replaced the placeholder `firebaseConfig` object in `Matthew Quiz` with the supplied Firebase project credentials and included the `databaseURL` and `measurementId` fields.

### Testing
- Verified the updated configuration block was written to `Matthew Quiz` by inspecting the file with `sed -n '340,380p' 'Matthew Quiz'` and `nl -ba 'Matthew Quiz' | sed -n '340,380p'` which showed the new values.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86a4bdd908329b13bd975f5c1ba79)